### PR TITLE
fix(meta): TrimSpace before returning OAuth2 state token read from STDIN

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -315,7 +315,7 @@ func (m *ApiMeta) Prompt() string {
 	reader := bufio.NewReader(os.Stdin)
 	m.Ui.Output(fmt.Sprintf("Paste authorization code:"))
 	text, _ := reader.ReadString('\n')
-	return text
+	return strings.TrimSpace(text)
 }
 
 func (m *ApiMeta) Help() string {


### PR DESCRIPTION
@jtk54  This PR fixes #1 by doing TrimSpace to the pasted state token. 