### PR TITLE
feat(endpoint): make gate endpoint configurable

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -61,10 +61,7 @@ type ApiMeta struct {
 	// Internal fields
 	color bool
 
-	// This is the set of flags global to the command parser.
-	gateEndpoint string
-
-        ignoreCertErrors bool
+	ignoreCertErrors bool
 
 	// Location of the spin config.
 	configLocation string
@@ -75,10 +72,10 @@ type ApiMeta struct {
 func (m *ApiMeta) GlobalFlagSet(cmd string) *flag.FlagSet {
 	f := flag.NewFlagSet(cmd, flag.ContinueOnError)
 
-	f.StringVar(&m.gateEndpoint, "gate-endpoint", "http://localhost:8084",
+	f.StringVar(&m.Config.GateEndpoint, "gate-endpoint", "http://localhost:8084",
 		"Gate (API server) endpoint")
 
-        f.BoolVar(&m.ignoreCertErrors, "insecure", false, "Ignore Certificate Errors")
+	f.BoolVar(&m.ignoreCertErrors, "insecure", false, "Ignore Certificate Errors")
 
 	f.Usage = func() {}
 
@@ -149,7 +146,7 @@ func (m *ApiMeta) Process(args []string) ([]string, error) {
 	}
 
 	cfg := &gate.Configuration{
-		BasePath:      m.gateEndpoint,
+		BasePath:      m.Config.GateEndpoint,
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "Spin CLI version", // TODO(jacobkiefer): Add a reasonable UserAgent.
 		HTTPClient:    client,
@@ -176,8 +173,8 @@ func (m *ApiMeta) InitializeClient() (*http.Client, error) {
 	}
 
 	if m.ignoreCertErrors {
-             http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-        }
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 
 	if auth != nil && auth.Enabled && auth.X509 != nil {
 		X509 := auth.X509
@@ -245,9 +242,9 @@ func (m *ApiMeta) initializeX509Config(client http.Client, clientCA []byte, cert
 	client.Transport.(*http.Transport).TLSClientConfig.MinVersion = tls.VersionTLS12
 	client.Transport.(*http.Transport).TLSClientConfig.PreferServerCipherSuites = true
 	client.Transport.(*http.Transport).TLSClientConfig.Certificates = []tls.Certificate{cert}
- 	if m.ignoreCertErrors {
-           client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
-        }
+	if m.ignoreCertErrors {
+		client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = true
+	}
 	return &client
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,5 +20,6 @@ import (
 
 // Config is the CLI configuration kept in '~/.spin/config'.
 type Config struct {
-	Auth *auth.AuthConfig `yaml:"auth"`
+	GateEndpoint string           `yaml:"gateEndpoint"`
+	Auth         *auth.AuthConfig `yaml:"auth"`
 }

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -1,5 +1,5 @@
 # NOTE: Copy this file to ~/.spin/config
-
+gateEndpoint: http://localhost:8080
 auth:
   enabled: true
   x509:


### PR DESCRIPTION
makes the `gateEndpoint` configurable via the config file. the flag
still works if the property is missing.

fixes spinnaker/spinnaker#3094