### PR TITLE
feat(config): gate endpoint configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,5 +20,8 @@ import (
 
 // Config is the CLI configuration kept in '~/.spin/config'.
 type Config struct {
+	Gate struct {
+		Endpoint string `yaml:"endpoint"`
+	} `yaml:"gate"`
 	Auth *auth.AuthConfig `yaml:"auth"`
 }


### PR DESCRIPTION
make `gate-endpoint` configurable via config file. the CLI flag takes
precedence over the config file.