### PR TITLE
refactor(gateclient): Cleanup around NewGateClient.

### DIFF
--- a/cmd/application/get.go
+++ b/cmd/application/get.go
@@ -58,10 +58,6 @@ func getApplication(cmd *cobra.Command, args []string) error {
 		return errors.New("application name required")
 	}
 	applicationName := args[0]
-	// TODO(jacobkiefer): Turns out using the type 'HashMap' doesn't help much in the CLI
-	// since json.Marshal* doesn't serialize it properly (it is not treated as a Map).
-	// We need to think of a strategy (e.g. Concrete types or deferring to just returning Object)
-	// In the cases where we use 'HashMap' currently.
 	app, resp, err := gateClient.ApplicationControllerApi.GetApplicationUsingGET(gateClient.Context, applicationName, map[string]interface{}{})
 	if resp != nil {
 		if resp.StatusCode == http.StatusNotFound {

--- a/cmd/application/list.go
+++ b/cmd/application/list.go
@@ -51,10 +51,6 @@ func listApplication(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	// TODO(jacobkiefer): Turns out using the type 'HashMap' doesn't help much in the CLI
-	// since json.Marshal* doesn't serialize it properly (it is not treated as a Map).
-	// We need to think of a strategy (e.g. Concrete types or deferring to just returning Object)
-	// In the cases where we use 'HashMap' currently.
 	appList, resp, err := gateClient.ApplicationControllerApi.GetAllApplicationsUsingGET(gateClient.Context, map[string]interface{}{})
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		SilenceUsage: true,
+		SilenceErrors: true,
 		Version:      version.String(),
 	}
 
@@ -36,8 +37,6 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&options.ignoreCertErrors, "insecure", "k", false, "ignore certificate errors")
 	cmd.PersistentFlags().BoolVarP(&options.quiet, "quiet", "q", false, "squelch non-essential output")
 	cmd.PersistentFlags().BoolVar(&options.color, "no-color", true, "disable color")
-	// TODO(jacobkiefer): Codify the json-path as part of an OutputConfig or
-	// something similar. Sets the stage for yaml output, etc.
 	cmd.PersistentFlags().StringVar(&options.outputFormat, "output", "", "configure output formatting")
 
 	// create subcommands


### PR DESCRIPTION
Clean-up refactor ahead of planned expansion for IAP-related changes. Also cleans up the double error printing from Cobra.