### PR TITLE
fix an issue where we can't read the body of this when passed

### DIFF
--- a/gateapi/pipeline_templates_controller_api.go
+++ b/gateapi/pipeline_templates_controller_api.go
@@ -67,7 +67,7 @@ func (a *PipelineTemplatesControllerApiService) CreateUsingPOST(ctx context.Cont
 		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
 	}
 	// body params
-	localVarPostBody = &pipelineTemplate
+	localVarPostBody = pipelineTemplate
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Ran into an issue were the body was being passed as nil. Spinnaker would return a 202 correctly.

```
client, err := gate.NewGateClient(flags)
if err != nil {
    return nil, err
}

raw, err := json.Marshal(tmp)
if err != nil {
    return err
}

resp, err := client.PipelineTemplatesControllerApi.CreateUsingPOST(client.Context, bytes.NewReader(raw))
if err != nil {
    return err
}
```