### PR TITLE
fix(pipeline): Removes constraint requiring id field.

### DIFF
--- a/cmd/pipeline/save.go
+++ b/cmd/pipeline/save.go
@@ -75,10 +75,6 @@ func savePipeline(cmd *cobra.Command, options SaveOptions) error {
 		valid = false
 	}
 
-	if _, exists := pipelineJson["id"]; !exists {
-		util.UI.Error("Required pipeline key 'id' missing...\n")
-		valid = false
-	}
 	if !valid {
 		return fmt.Errorf("Submitted pipeline is invalid: %s\n", pipelineJson)
 	}

--- a/cmd/pipeline/save_test.go
+++ b/cmd/pipeline/save_test.go
@@ -162,7 +162,7 @@ func TestPipelineSave_missingid(t *testing.T) {
 
 	rootCmd.SetArgs(args)
 	err := rootCmd.Execute()
-	if err == nil {
+	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
 }


### PR DESCRIPTION
Helps support pipeline templates and was overly strict anyway
since Orca generates a UUID anyway and the other pipeline commands
operate on name/app pair.