### PR TITLE
fix(app): Fixes specifying apps with flags only.

### DIFF
--- a/cmd/application/save.go
+++ b/cmd/application/save.go
@@ -64,9 +64,10 @@ func saveApplication(cmd *cobra.Command, options SaveOptions) error {
 	if err != nil {
 		return err
 	}
-	initialApp, err := util.ParseJsonFromFileOrStdin(options.applicationFile)
+
+	initialApp, err := util.ParseJsonFromFileOrStdin(options.applicationFile, true)
 	if err != nil {
-		util.UI.Error(fmt.Sprintf("%s\n", err))
+		return fmt.Errorf("Could not parse supplied application: %v.\n", err)
 	}
 
 	var app map[string]interface{}

--- a/cmd/pipeline-template/plan.go
+++ b/cmd/pipeline-template/plan.go
@@ -57,7 +57,7 @@ func planPipelineTemplate(cmd *cobra.Command, options PlanOptions) error {
 		return err
 	}
 
-	configJson, err := util.ParseJsonFromFileOrStdin(options.configPath)
+	configJson, err := util.ParseJsonFromFileOrStdin(options.configPath, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline-template/save.go
+++ b/cmd/pipeline-template/save.go
@@ -58,7 +58,7 @@ func savePipelineTemplate(cmd *cobra.Command, options SaveOptions) error {
 		return err
 	}
 
-	templateJson, err := util.ParseJsonFromFileOrStdin(options.pipelineFile)
+	templateJson, err := util.ParseJsonFromFileOrStdin(options.pipelineFile, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/execute.go
+++ b/cmd/pipeline/execute.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -70,11 +69,7 @@ func executePipeline(cmd *cobra.Command, options ExecuteOptions) error {
 		return errors.New("one of required parameters 'application' or 'name' not set")
 	}
 	parameters := map[string]interface{}{}
-	parameters, err = util.ParseJsonFromFileOrStdin(options.parameterFile)
-	if err != nil && strings.HasPrefix(err.Error(), "No json input") {
-		// Pipeline can be executed with no parameters.
-		parameters, err = nil, nil
-	}
+	parameters, err = util.ParseJsonFromFileOrStdin(options.parameterFile, true)
 	if err != nil {
 		return fmt.Errorf("Could not parse supplied pipeline parameters: %v.\n", err)
 	}

--- a/cmd/pipeline/save.go
+++ b/cmd/pipeline/save.go
@@ -60,7 +60,7 @@ func savePipeline(cmd *cobra.Command, options SaveOptions) error {
 		return err
 	}
 
-	pipelineJson, err := util.ParseJsonFromFileOrStdin(options.pipelineFile)
+	pipelineJson, err := util.ParseJsonFromFileOrStdin(options.pipelineFile, false)
 	if err != nil {
 		return err
 	}

--- a/util/json_reader.go
+++ b/util/json_reader.go
@@ -20,7 +20,7 @@ import (
 	"os"
 )
 
-func ParseJsonFromFileOrStdin(filePath string) (map[string]interface{}, error) {
+func ParseJsonFromFileOrStdin(filePath string, tolerateEmptyStdin bool) (map[string]interface{}, error) {
 	var fromFile *os.File
 	var err error
 	var jsonContent map[string]interface{}
@@ -41,7 +41,11 @@ func ParseJsonFromFileOrStdin(filePath string) (map[string]interface{}, error) {
 
 	pipedStdin := (fi.Mode() & os.ModeCharDevice) == 0
 	if fi.Size() <= 0 && !pipedStdin {
-		return nil, errors.New("No json input to parse.")
+		err = nil
+		if !tolerateEmptyStdin {
+      err = errors.New("No json input to parse.")
+		}
+		return nil, err
 	}
 
 	err = json.NewDecoder(fromFile).Decode(&jsonContent)


### PR DESCRIPTION
Previously the command would fail if there was no file input from either a flag or STDIN, which was a regression.