### PR TITLE
fix(app): Fails on deleting non-existent app.

### DIFF
--- a/cmd/application/delete.go
+++ b/cmd/application/delete.go
@@ -64,12 +64,22 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	createAppTask := map[string]interface{}{
+	_, resp, err := gateClient.ApplicationControllerApi.GetApplicationUsingGET(gateClient.Context, applicationName, map[string]interface{}{"expand": false})
+
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("Attempting to delete application '%s' which does not exist, exiting...", applicationName)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Encountered an error checking application existence, status code: %d\n", resp.StatusCode)
+	}
+
+	deleteAppTask := map[string]interface{}{
 		"job":         []interface{}{appSpec},
 		"application": applicationName,
 		"description": fmt.Sprintf("Delete Application: %s", applicationName),
 	}
-	_, resp, err := gateClient.TaskControllerApi.TaskUsingPOST1(gateClient.Context, createAppTask)
+	_, resp, err = gateClient.TaskControllerApi.TaskUsingPOST1(gateClient.Context, deleteAppTask)
 
 	if err != nil {
 		return err

--- a/cmd/application/get.go
+++ b/cmd/application/get.go
@@ -53,7 +53,7 @@ func NewGetCmd(appOptions applicationOptions) *cobra.Command {
 	}
 
 	// Note that false here means defaults to false, and flips to true if the flag is present.
-	cmd.PersistentFlags().BoolVarP(&options.expand, "expand", "x", false, "email of the application owner")
+	cmd.PersistentFlags().BoolVarP(&options.expand, "expand", "x", false, "expand app payload to include clusters")
 
 	return cmd
 }


### PR DESCRIPTION
Also fixes incorrect flag help text in `app get`.