### PR TITLE
fix(iap): Clear err variable after printing link.

### DIFF
--- a/config/auth/iap/user_iap_auth_helper.go
+++ b/config/auth/iap/user_iap_auth_helper.go
@@ -56,6 +56,7 @@ func GetIapToken(iapConfig IapConfig) (string, error) {
 	url := getOauthUrl(clientId, clientState, port)
 
 	if err = execcmd.OpenUrl(url); err != nil {
+		err = nil
 		fmt.Printf("Go to the following link in your browser:\n%s\n\n", url)
 	} else {
 		fmt.Printf("Your browser has been opened to visit:\n%s\n\n", url)


### PR DESCRIPTION
Without this fix, the error is still propagated even though the user has followed the displayed link.