### PR TITLE
feat(gateclient): add default-headers flag for gate client requests

### DIFF
--- a/cmd/application/get_test.go
+++ b/cmd/application/get_test.go
@@ -39,6 +39,7 @@ func getRootCmdForTest() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
 	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
+	rootCmd.PersistentFlags().String("default-headers", "", "Configure addtional headers for gate client requests")
 	util.InitUI(false, false, "")
 	return rootCmd
 }

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -131,9 +131,24 @@ func NewGateClient(flags *pflag.FlagSet) (*GatewayClient, error) {
 		return nil, err
 	}
 
+	m := make(map[string]string)
+
+	defaultHeaders, err := flags.GetString("default-headers")
+	if err != nil {
+		return nil, err
+	}
+
+	if defaultHeaders != "" {
+		headers := strings.Split(defaultHeaders, ",")
+		for _, element := range headers {
+			header := strings.Split(element, "=")
+			m[strings.TrimSpace(header[0])] = strings.TrimSpace(header[1])
+		}
+	}
+
 	cfg := &gate.Configuration{
 		BasePath:      gateClient.GateEndpoint(),
-		DefaultHeader: make(map[string]string),
+		DefaultHeader: m,
 		UserAgent:     fmt.Sprintf("%s/%s", version.UserAgent, version.String()),
 		HTTPClient:    httpClient,
 	}

--- a/cmd/pipeline-template/get_test.go
+++ b/cmd/pipeline-template/get_test.go
@@ -33,6 +33,7 @@ func getRootCmdForTest() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
 	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
+	rootCmd.PersistentFlags().String("default-headers", "", "Configure addtional headers for gate client requests")
 	util.InitUI(false, false, "")
 	return rootCmd
 }

--- a/cmd/pipeline/execution/get_test.go
+++ b/cmd/pipeline/execution/get_test.go
@@ -33,6 +33,7 @@ func getRootCmdForTest() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
 	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
+	rootCmd.PersistentFlags().String("default-headers", "", "Configure addtional headers for gate client requests")
 	util.InitUI(false, false, "")
 	return rootCmd
 }

--- a/cmd/pipeline/get_test.go
+++ b/cmd/pipeline/get_test.go
@@ -34,6 +34,7 @@ func getRootCmdForTest() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
 	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
+	rootCmd.PersistentFlags().String("default-headers", "", "Configure addtional headers for gate client requests")
 	util.InitUI(false, false, "")
 	return rootCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ type RootOptions struct {
 	quiet            bool
 	color            bool
 	outputFormat     string
+	defaultHeaders   string
 }
 
 func Execute(out io.Writer) error {
@@ -39,6 +40,7 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&options.quiet, "quiet", "q", false, "squelch non-essential output")
 	cmd.PersistentFlags().BoolVar(&options.color, "no-color", true, "disable color")
 	cmd.PersistentFlags().StringVar(&options.outputFormat, "output", "", "configure output formatting")
+	cmd.PersistentFlags().StringVar(&options.defaultHeaders, "default-headers", "", "configure default headers for gate client as comma separated list (e.g. key1=value1,key2=value2)")
 
 	// create subcommands
 	cmd.AddCommand(application.NewApplicationCmd(out))


### PR DESCRIPTION
This PR provides functionality requested in issue #180

A new flag has been added for default-headers which accepts a comma separated list of key value pairs of headers that will be set as defaults on the gate client to be sent through on each request to the gate endpoint.

As mentioned in issue #180 the purpose of this was to allow passing custom headers that may be required if the gate endpoint is only exposed via some sort of api gateway.

## Example Usage
`./spin application list --gate-endpoint=https://myapigateway.test.com/gate --default-headers=X-Api-Service-Key=secrettoken,secondHeaderKey=value`

## Tests
this is the output from running the go tests:

```
?   	github.com/spinnaker/spin	[no test files]
?   	github.com/spinnaker/spin/cmd	[no test files]
ok  	github.com/spinnaker/spin/cmd/application	0.379s
?   	github.com/spinnaker/spin/cmd/gateclient	[no test files]
?   	github.com/spinnaker/spin/cmd/orca-tasks	[no test files]
?   	github.com/spinnaker/spin/cmd/output	[no test files]
ok  	github.com/spinnaker/spin/cmd/pipeline	1.352s
ok  	github.com/spinnaker/spin/cmd/pipeline/execution	0.365s
ok  	github.com/spinnaker/spin/cmd/pipeline-template	0.344s
?   	github.com/spinnaker/spin/config	[no test files]
?   	github.com/spinnaker/spin/config/auth	[no test files]
?   	github.com/spinnaker/spin/config/auth/basic	[no test files]
?   	github.com/spinnaker/spin/config/auth/googleserviceaccount	[no test files]
ok  	github.com/spinnaker/spin/config/auth/iap	(cached)
?   	github.com/spinnaker/spin/config/auth/oauth2	[no test files]
?   	github.com/spinnaker/spin/config/auth/x509	[no test files]
?   	github.com/spinnaker/spin/gateapi	[no test files]
?   	github.com/spinnaker/spin/util	[no test files]
?   	github.com/spinnaker/spin/util/execcmd	[no test files]
?   	github.com/spinnaker/spin/version	[no test files]
```

I have tested building and using spin hitting both a local gate endpoint without any default headers, as well as hitting gate behind an api gateway while passing through the --default-headers flag