### PR TITLE
feat(docker): Add Dockerfile for building Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.12 as build
+ARG VERSION
+
+WORKDIR /app
+COPY ./ ./
+
+RUN ./build.sh --go-os linux --go-arch amd64 --version "${VERSION:-}"
+
+
+
+FROM alpine
+
+RUN apk update \
+    && apk add ca-certificates \
+    && rm -rf /var/cache/apk/*
+
+COPY --from=build /app/spin /usr/local/bin
+
+CMD ["/bin/sh"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,9 @@
+FROM alpine
+
+RUN apk update \
+    && apk add ca-certificates \
+    && rm -rf /var/cache/apk/*
+
+COPY spin /usr/local/bin
+
+CMD ["/bin/sh"]

--- a/release.sh
+++ b/release.sh
@@ -75,7 +75,6 @@ fi
 
 gcloud auth activate-service-account --key-file ${KEY_FILE}
 gcloud components install gsutil -q
-gcloud auth configure-docker -q
 
 if [ -z "$VERSION" ]; then
   echo -e "No version to release specified with --version, exiting"
@@ -101,18 +100,6 @@ for elem in darwin,amd64 linux,amd64 windows,amd64; do
   echo "Copying $file to $path"
 
   gsutil cp $file $path
-
-  if [ "$elem" = "linux,amd64" ]; then
-    echo "Building Docker image gcr.io/spinnaker-marketplace/spin:${VERSION}"
-
-    docker build -t gcr.io/spinnaker-marketplace/spin:${VERSION} -f Dockerfile.slim .
-    docker push gcr.io/spinnaker-marketplace/spin:${VERSION}
-
-    # Also publish as :latest
-    docker tag gcr.io/spinnaker-marketplace/spin:${VERSION} gcr.io/spinnaker-marketplace/spin:latest
-    docker push gcr.io/spinnaker-marketplace/spin:latest
-  fi
-
   rm $file
 done
 

--- a/release.sh
+++ b/release.sh
@@ -75,6 +75,7 @@ fi
 
 gcloud auth activate-service-account --key-file ${KEY_FILE}
 gcloud components install gsutil -q
+gcloud auth configure-docker -q
 
 if [ -z "$VERSION" ]; then
   echo -e "No version to release specified with --version, exiting"
@@ -100,6 +101,18 @@ for elem in darwin,amd64 linux,amd64 windows,amd64; do
   echo "Copying $file to $path"
 
   gsutil cp $file $path
+
+  if [ "$elem" = "linux,amd64" ]; then
+    echo "Building Docker image gcr.io/spinnaker-marketplace/spin:${VERSION}"
+
+    docker build -t gcr.io/spinnaker-marketplace/spin:${VERSION} -f Dockerfile.slim .
+    docker push gcr.io/spinnaker-marketplace/spin:${VERSION}
+
+    # Also publish as :latest
+    docker tag gcr.io/spinnaker-marketplace/spin:${VERSION} gcr.io/spinnaker-marketplace/spin:latest
+    docker push gcr.io/spinnaker-marketplace/spin:latest
+  fi
+
   rm $file
 done
 


### PR DESCRIPTION
This allows a complete build using Docker, or building an image from an already compiled copy using using Dockerfile.slim.

This partially addresses https://github.com/spinnaker/spinnaker/issues/4531. Further modifications are probably required to https://github.com/spinnaker/spinnaker/blob/master/dev/buildtool/spin_commands.py to address release publication.