### PR TITLE
fix(gateclient): Allow for header values with equal sign.

### DIFF
--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -147,7 +147,10 @@ func NewGateClient(flags *pflag.FlagSet) (*GatewayClient, error) {
 	if defaultHeaders != "" {
 		headers := strings.Split(defaultHeaders, ",")
 		for _, element := range headers {
-			header := strings.Split(element, "=")
+			header := strings.SplitN(element, "=", 2)
+			if len(header) != 2 {
+				return nil, fmt.Errorf("Bad default-header value, use key=value form: %s", element)
+			}
 			m[strings.TrimSpace(header[0])] = strings.TrimSpace(header[1])
 		}
 	}


### PR DESCRIPTION
Since we're using Okta SAML to authenticate with Spinnaker, I figured I
would extract my SESSION cookie from the browser and use
--default-header Cookie=SESSION=x in the spin cli tool.

This code makes that work and stops stripping away everything after the
second equal sign. Additionally an error is now printed if you try to
use the flag without an equal sign. Previously a stack trace was
generated instead.