### PR TITLE
fix(cmd): handle calls to version endpoint in tests

### DIFF
--- a/cmd/application/delete_test.go
+++ b/cmd/application/delete_test.go
@@ -20,8 +20,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestApplicationDelete_basic(t *testing.T) {
@@ -81,15 +82,8 @@ func TestApplicationDelete_flags(t *testing.T) {
 // testGateApplicationDeleteSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with successful responses to pipeline execute API calls.
 func testGateApplicationDeleteSuccess() *httptest.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payload := map[string]string{
-			"version": "Unknown",
-		}
-		b, _ := json.Marshal(&payload)
-		fmt.Fprintln(w, string(b))
-	}))
-	mux.Handle("/applications/" + APP, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/applications/"+APP, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		payload := map[string]string{} // We don't use the payload, we are just checking if the target app exists.
 		b, _ := json.Marshal(&payload)
 		fmt.Fprintln(w, string(b))
@@ -114,16 +108,10 @@ func testGateApplicationDeleteSuccess() *httptest.Server {
 // GateAppDeleteFail spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 500 InternalServerError.
 func GateAppDeleteFail() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/applications/"+APP, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}))
+	return httptest.NewServer(mux)
 }

--- a/cmd/application/list_test.go
+++ b/cmd/application/list_test.go
@@ -15,6 +15,7 @@
 package application
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -81,14 +82,30 @@ func TestApplicationList_fail(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed application list.
 func testGateApplicationListSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(applicationListJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(applicationListJson))
+		}
 	}))
 }
 
 // testGateApplicationListMalformed returns a malformed list of application configs.
 func testGateApplicationListMalformed() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(malformedApplicationListJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(malformedApplicationListJson))
+		}
 	}))
 }
 

--- a/cmd/application/save_test.go
+++ b/cmd/application/save_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 const (
@@ -240,14 +242,7 @@ func GateServerFail() *httptest.Server {
 // testGatePipelineExecuteSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with successful responses to pipeline execute API calls.
 func testGateApplicationSaveSuccess() *httptest.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payload := map[string]string{
-			"version": "Unknown",
-		}
-		b, _ := json.Marshal(&payload)
-		fmt.Fprintln(w, string(b))
-	}))
+	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/tasks", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		payload := map[string]string{
 			"ref": "/tasks/id",

--- a/cmd/application/save_test.go
+++ b/cmd/application/save_test.go
@@ -241,6 +241,13 @@ func GateServerFail() *httptest.Server {
 // to direct requests to. Responds with successful responses to pipeline execute API calls.
 func testGateApplicationSaveSuccess() *httptest.Server {
 	mux := http.NewServeMux()
+	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]string{
+			"version": "Unknown",
+		}
+		b, _ := json.Marshal(&payload)
+		fmt.Fprintln(w, string(b))
+	}))
 	mux.Handle("/tasks", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		payload := map[string]string{
 			"ref": "/tasks/id",

--- a/cmd/pipeline-template/delete_test.go
+++ b/cmd/pipeline-template/delete_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	gate "github.com/spinnaker/spin/gateapi"
+	"github.com/spinnaker/spin/util"
 )
 
 func TestPipelineTemplateDelete_basic(t *testing.T) {
@@ -119,14 +120,7 @@ func TestPipelineTemplateDelete_missingid(t *testing.T) {
 // to direct requests to. Responds with OK to indicate a pipeline template exists,
 // and Accepts POST calls.
 func gateServerDeleteSuccess() *httptest.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payload := map[string]string{
-			"version": "Unknown",
-		}
-		b, _ := json.Marshal(&payload)
-		fmt.Fprintln(w, string(b))
-	}))
+	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/v2/pipelineTemplates/myTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete {
 			resp := gate.ResponseEntity{StatusCode: "201 Accepted", StatusCodeValue: 201}

--- a/cmd/pipeline-template/delete_test.go
+++ b/cmd/pipeline-template/delete_test.go
@@ -120,6 +120,13 @@ func TestPipelineTemplateDelete_missingid(t *testing.T) {
 // and Accepts POST calls.
 func gateServerDeleteSuccess() *httptest.Server {
 	mux := http.NewServeMux()
+	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]string{
+			"version": "Unknown",
+		}
+		b, _ := json.Marshal(&payload)
+		fmt.Fprintln(w, string(b))
+	}))
 	mux.Handle("/v2/pipelineTemplates/myTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete {
 			resp := gate.ResponseEntity{StatusCode: "201 Accepted", StatusCodeValue: 201}

--- a/cmd/pipeline-template/get_test.go
+++ b/cmd/pipeline-template/get_test.go
@@ -14,7 +14,6 @@
 package pipeline_template
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -172,47 +171,29 @@ func TestPipelineGet_notfound(t *testing.T) {
 // testGatePipelineGetSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 200 and a well-formed pipeline get response.
 func testGatePipelineTemplateGetSuccess() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(pipelineTemplateGetJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/v2/pipelineTemplates/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(pipelineTemplateGetJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 // testGatePipelineGetMalformed returns a malformed get response of pipeline configs.
 func testGatePipelineTemplateGetMalformed() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(malformedPipelineTemplateGetJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/v2/pipelineTemplates/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineTemplateGetJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 // testGatePipelineGetMissing returns a 404 Not Found for an errant pipeline name|application pair.
 func testGatePipelineTemplateGetMissing() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			http.NotFound(w, r)
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/v2/pipelineTemplates/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
 	}))
+	return httptest.NewServer(mux)
 }
 
 // GateServerFail spins up a local http server that we will configure the GateClient

--- a/cmd/pipeline-template/get_test.go
+++ b/cmd/pipeline-template/get_test.go
@@ -14,15 +14,16 @@
 package pipeline_template
 
 import (
-"fmt"
-"net/http"
-"net/http/httptest"
-"os"
-"strings"
-"testing"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
 
-"github.com/spf13/cobra"
-"github.com/spinnaker/spin/util"
+	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/util"
 )
 
 func getRootCmdForTest() *cobra.Command {
@@ -172,21 +173,45 @@ func TestPipelineGet_notfound(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed pipeline get response.
 func testGatePipelineTemplateGetSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(pipelineTemplateGetJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(pipelineTemplateGetJson))
+		}
 	}))
 }
 
 // testGatePipelineGetMalformed returns a malformed get response of pipeline configs.
 func testGatePipelineTemplateGetMalformed() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineTemplateGetJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(malformedPipelineTemplateGetJson))
+		}
 	}))
 }
 
 // testGatePipelineGetMissing returns a 404 Not Found for an errant pipeline name|application pair.
 func testGatePipelineTemplateGetMissing() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.NotFound(w, r)
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			http.NotFound(w, r)
+		}
 	}))
 }
 

--- a/cmd/pipeline-template/list_test.go
+++ b/cmd/pipeline-template/list_test.go
@@ -15,13 +15,14 @@
 package pipeline_template
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestPipelineTemplateList_basic(t *testing.T) {
@@ -99,48 +100,30 @@ func TestPipelineTemplateList_fail(t *testing.T) {
 // testGatePipelineTemplateListSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 200 and a well-formed pipelineTemplate list.
 func testGatePipelineTemplateListSuccess() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(pipelineTemplateListJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/v2/pipelineTemplates/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(pipelineTemplateListJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 // testGateScopedPipelineTemplateListSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 200 and a well-formed pipelineTemplate list.
 func testGateScopedPipelineTemplateListSuccess() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(scopedPipelineTemplateListJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/v2/pipelineTemplates/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(scopedPipelineTemplateListJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 // testGatePipelineTemplateListMalformed returns a malformed list of pipelineTemplate configs.
 func testGatePipelineTemplateListMalformed() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(malformedPipelineTemplateListJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/v2/pipelineTemplates/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineTemplateListJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 const malformedPipelineTemplateListJson = `

--- a/cmd/pipeline-template/list_test.go
+++ b/cmd/pipeline-template/list_test.go
@@ -15,6 +15,7 @@
 package pipeline_template
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -99,7 +100,15 @@ func TestPipelineTemplateList_fail(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed pipelineTemplate list.
 func testGatePipelineTemplateListSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(pipelineTemplateListJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(pipelineTemplateListJson))
+		}
 	}))
 }
 
@@ -107,14 +116,30 @@ func testGatePipelineTemplateListSuccess() *httptest.Server {
 // to direct requests to. Responds with a 200 and a well-formed pipelineTemplate list.
 func testGateScopedPipelineTemplateListSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(scopedPipelineTemplateListJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(scopedPipelineTemplateListJson))
+		}
 	}))
 }
 
 // testGatePipelineTemplateListMalformed returns a malformed list of pipelineTemplate configs.
 func testGatePipelineTemplateListMalformed() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineTemplateListJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(malformedPipelineTemplateListJson))
+		}
 	}))
 }
 

--- a/cmd/pipeline-template/plan_test.go
+++ b/cmd/pipeline-template/plan_test.go
@@ -15,13 +15,14 @@
 package pipeline_template
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestPipelineTemplatePlan_basic(t *testing.T) {
@@ -124,14 +125,7 @@ func TestPipelineTemplatePlan_flags(t *testing.T) {
 // to direct requests to. Responds with 404 NotFound to indicate a pipeline template doesn't exist,
 // and Accepts POST calls.
 func gateServerPlanSuccess() *httptest.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payload := map[string]string{
-			"version": "Unknown",
-		}
-		b, _ := json.Marshal(&payload)
-		fmt.Fprintln(w, string(b))
-	}))
+	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/v2/pipelineTemplates/plan", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			fmt.Fprintln(w, strings.TrimSpace(testPipelineTemplatePlanResp))

--- a/cmd/pipeline-template/plan_test.go
+++ b/cmd/pipeline-template/plan_test.go
@@ -15,6 +15,7 @@
 package pipeline_template
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -124,6 +125,13 @@ func TestPipelineTemplatePlan_flags(t *testing.T) {
 // and Accepts POST calls.
 func gateServerPlanSuccess() *httptest.Server {
 	mux := http.NewServeMux()
+	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]string{
+			"version": "Unknown",
+		}
+		b, _ := json.Marshal(&payload)
+		fmt.Fprintln(w, string(b))
+	}))
 	mux.Handle("/v2/pipelineTemplates/plan", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			fmt.Fprintln(w, strings.TrimSpace(testPipelineTemplatePlanResp))

--- a/cmd/pipeline-template/save_test.go
+++ b/cmd/pipeline-template/save_test.go
@@ -15,13 +15,14 @@
 package pipeline_template
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestPipelineTemplateSave_create(t *testing.T) {
@@ -254,14 +255,7 @@ func tempPipelineTemplateFile(pipelineContent string) *os.File {
 // to direct requests to. Responds with OK to indicate a pipeline template exists,
 // and Accepts POST calls.
 func gateServerUpdateSuccess() *httptest.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payload := map[string]string{
-			"version": "Unknown",
-		}
-		b, _ := json.Marshal(&payload)
-		fmt.Fprintln(w, string(b))
-	}))
+	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/v2/pipelineTemplates/update/testSpelTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusAccepted)
@@ -280,14 +274,7 @@ func gateServerUpdateSuccess() *httptest.Server {
 // to direct requests to. Responds with 404 NotFound to indicate a pipeline template doesn't exist,
 // and Accepts POST calls.
 func gateServerCreateSuccess() *httptest.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payload := map[string]string{
-			"version": "Unknown",
-		}
-		b, _ := json.Marshal(&payload)
-		fmt.Fprintln(w, string(b))
-	}))
+	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/v2/pipelineTemplates/create", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusAccepted)

--- a/cmd/pipeline-template/save_test.go
+++ b/cmd/pipeline-template/save_test.go
@@ -15,6 +15,7 @@
 package pipeline_template
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -254,6 +255,13 @@ func tempPipelineTemplateFile(pipelineContent string) *os.File {
 // and Accepts POST calls.
 func gateServerUpdateSuccess() *httptest.Server {
 	mux := http.NewServeMux()
+	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]string{
+			"version": "Unknown",
+		}
+		b, _ := json.Marshal(&payload)
+		fmt.Fprintln(w, string(b))
+	}))
 	mux.Handle("/v2/pipelineTemplates/update/testSpelTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusAccepted)
@@ -273,6 +281,13 @@ func gateServerUpdateSuccess() *httptest.Server {
 // and Accepts POST calls.
 func gateServerCreateSuccess() *httptest.Server {
 	mux := http.NewServeMux()
+	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]string{
+			"version": "Unknown",
+		}
+		b, _ := json.Marshal(&payload)
+		fmt.Fprintln(w, string(b))
+	}))
 	mux.Handle("/v2/pipelineTemplates/create", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			w.WriteHeader(http.StatusAccepted)

--- a/cmd/pipeline/execute_test.go
+++ b/cmd/pipeline/execute_test.go
@@ -146,6 +146,13 @@ func TestPipelineExecute_missingapp(t *testing.T) {
 // to direct requests to. Responds with successful responses to pipeline execute API calls.
 func testGatePipelineExecuteSuccess() *httptest.Server {
 	mux := http.NewServeMux()
+	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]string{
+			"version": "Unknown",
+		}
+		b, _ := json.Marshal(&payload)
+		fmt.Fprintln(w, string(b))
+	}))
 	mux.Handle("/pipelines/app/one", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := gate.ResponseEntity{StatusCode: "201 Accepted", StatusCodeValue: 201}
 		b, _ := json.Marshal(&resp)

--- a/cmd/pipeline/execute_test.go
+++ b/cmd/pipeline/execute_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	gate "github.com/spinnaker/spin/gateapi"
+	"github.com/spinnaker/spin/util"
 )
 
 // TODO(jacobkiefer): This test overlaps heavily with pipeline_save_test.go,
@@ -145,14 +146,7 @@ func TestPipelineExecute_missingapp(t *testing.T) {
 // testGatePipelineExecuteSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with successful responses to pipeline execute API calls.
 func testGatePipelineExecuteSuccess() *httptest.Server {
-	mux := http.NewServeMux()
-	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payload := map[string]string{
-			"version": "Unknown",
-		}
-		b, _ := json.Marshal(&payload)
-		fmt.Fprintln(w, string(b))
-	}))
+	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/pipelines/app/one", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := gate.ResponseEntity{StatusCode: "201 Accepted", StatusCodeValue: 201}
 		b, _ := json.Marshal(&resp)

--- a/cmd/pipeline/execution/cancel_test.go
+++ b/cmd/pipeline/execution/cancel_test.go
@@ -15,10 +15,12 @@
 package execution
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -86,6 +88,14 @@ func TestExecutionCancel_failure(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed pipeline get response.
 func testGateExecutionCancelSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "")
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, "")
+		}
 	}))
 }

--- a/cmd/pipeline/execution/get_test.go
+++ b/cmd/pipeline/execution/get_test.go
@@ -15,6 +15,7 @@
 package execution
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/util"
@@ -102,7 +103,15 @@ func TestExecutionGet_failure(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed pipeline get response.
 func testGateExecutionGetSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(executionGetJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(executionGetJson))
+		}
 	}))
 }
 
@@ -110,8 +119,16 @@ func testGateExecutionGetSuccess() *httptest.Server {
 // to direct requests to. Responds with a 500 InternalServerError.
 func GateServerFail() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		}
 	}))
 }
 

--- a/cmd/pipeline/execution/list_test.go
+++ b/cmd/pipeline/execution/list_test.go
@@ -15,6 +15,7 @@
 package execution
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -82,7 +83,15 @@ func TestExecutionList_fail(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed execution list.
 func testGateExecutionListSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(executionListJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(executionListJson))
+		}
 	}))
 }
 

--- a/cmd/pipeline/get_test.go
+++ b/cmd/pipeline/get_test.go
@@ -15,7 +15,6 @@
 package pipeline
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -134,47 +133,29 @@ func TestPipelineGet_notfound(t *testing.T) {
 // testGatePipelineGetSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 200 and a well-formed pipeline get response.
 func testGatePipelineGetSuccess() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(pipelineGetJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/applications/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(pipelineGetJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 // testGatePipelineGetMalformed returns a malformed get response of pipeline configs.
 func testGatePipelineGetMalformed() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(malformedPipelineGetJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/applications/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineGetJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 // testGatePipelineGetMissing returns a 404 Not Found for an errant pipeline name|application pair.
 func testGatePipelineGetMissing() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			http.NotFound(w, r)
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/applications/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
 	}))
+	return httptest.NewServer(mux)
 }
 
 const malformedPipelineGetJson = `

--- a/cmd/pipeline/get_test.go
+++ b/cmd/pipeline/get_test.go
@@ -15,6 +15,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -134,21 +135,45 @@ func TestPipelineGet_notfound(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed pipeline get response.
 func testGatePipelineGetSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(pipelineGetJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(pipelineGetJson))
+		}
 	}))
 }
 
 // testGatePipelineGetMalformed returns a malformed get response of pipeline configs.
 func testGatePipelineGetMalformed() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineGetJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(malformedPipelineGetJson))
+		}
 	}))
 }
 
 // testGatePipelineGetMissing returns a 404 Not Found for an errant pipeline name|application pair.
 func testGatePipelineGetMissing() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.NotFound(w, r)
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			http.NotFound(w, r)
+		}
 	}))
 }
 

--- a/cmd/pipeline/list_test.go
+++ b/cmd/pipeline/list_test.go
@@ -15,13 +15,14 @@
 package pipeline
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestPipelineList_basic(t *testing.T) {
@@ -100,32 +101,20 @@ func TestPipelineList_fail(t *testing.T) {
 // testGatePipelineListSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 200 and a well-formed pipeline list.
 func testGatePipelineListSuccess() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(pipelineListJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/applications/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(pipelineListJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 // testGatePipelineListMalformed returns a malformed list of pipeline configs.
 func testGatePipelineListMalformed() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.String(), "/version") {
-			payload := map[string]string{
-				"version": "Unknown",
-			}
-			b, _ := json.Marshal(&payload)
-			fmt.Fprintln(w, string(b))
-		} else {
-			fmt.Fprintln(w, strings.TrimSpace(malformedPipelineListJson))
-		}
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/applications/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineListJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 const malformedPipelineListJson = `

--- a/cmd/pipeline/list_test.go
+++ b/cmd/pipeline/list_test.go
@@ -15,6 +15,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -100,14 +101,30 @@ func TestPipelineList_fail(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed pipeline list.
 func testGatePipelineListSuccess() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(pipelineListJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(pipelineListJson))
+		}
 	}))
 }
 
 // testGatePipelineListMalformed returns a malformed list of pipeline configs.
 func testGatePipelineListMalformed() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineListJson))
+		if strings.Contains(r.URL.String(), "/version") {
+			payload := map[string]string{
+				"version": "Unknown",
+			}
+			b, _ := json.Marshal(&payload)
+			fmt.Fprintln(w, string(b))
+		} else {
+			fmt.Fprintln(w, strings.TrimSpace(malformedPipelineListJson))
+		}
 	}))
 }
 

--- a/util/test_helpers.go
+++ b/util/test_helpers.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func TestGateMuxWithVersionHandler() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/version", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]string{
+			"version": "Unknown",
+		}
+		b, _ := json.Marshal(&payload)
+		fmt.Fprintln(w, string(b))
+	}))
+
+	return mux
+}


### PR DESCRIPTION
First question is are the tests currently running in Travis? I was unable to run the tests successfully (for any tests targeting a test server representing Gate) on a clean clone. Assuming I don't have something wrong with my local, it looks like none of the test servers were handling a route for `/version` -- https://github.com/spinnaker/spin/blob/master/cmd/gateclient/client.go#L167-L171

This change adds handling for that (~rather verbosely but would like the get the tests passing first before I work on the changes I had in mind)~. These changes allowed for me to run the tests locally on a clean branch. I can follow-up to abstract the configuring of the test servers as needed.

If I'm correct that the tests are not running against PRs (quick glance at a recent PR, I didn't see a status for it), what would it take to get those running again?