### PR TITLE
fix(cmd): Fix pipeline save error detection

### DIFF
--- a/cmd/pipeline/save.go
+++ b/cmd/pipeline/save.go
@@ -107,8 +107,7 @@ func savePipeline(cmd *cobra.Command, options SaveOptions) error {
 	saveResp, saveErr := gateClient.PipelineControllerApi.SavePipelineUsingPOST(gateClient.Context, pipelineJson)
 
 	if saveErr != nil {
-		fmt.Printf("s err: %v", saveErr)
-		return err
+		return saveErr
 	}
 	if saveResp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Encountered an error saving pipeline, status code: %d\n", saveResp.StatusCode)


### PR DESCRIPTION
A fix for https://github.com/spinnaker/spinnaker/issues/5092, makes `spin` correctly return a non-zero exit code and outputs error to stderr. 
Additonally, added a test for this case, simulating non-authorized write attempt. 