### PR TITLE
docs(config/example): Update link reference to "ssl"

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -5,7 +5,7 @@ gate:
 auth:
   enabled: true
   x509:
-    # See https://www.spinnaker.io/setup/security/authentication/ssl/ and
+    # See https://www.spinnaker.io/setup/security/ssl/ and
     # https://www.spinnaker.io/setup/security/authentication/x509/ for guides on creating
     # the key and cert files.
     certPath: "~/.spin/certpath"


### PR DESCRIPTION
The link to ssl was broken and I guess it should target https://www.spinnaker.io/setup/security/ssl/ instead.
I've opened a [PR](https://github.com/spinnaker/spinnaker.github.io/pull/1596) into the spinnaker documentation web site as well.