### PR TITLE
feat(auth): Allow command line credentials when using ldap authN

### DIFF
--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -134,7 +134,7 @@ func NewGateClient(flags *pflag.FlagSet) (*GatewayClient, error) {
 		return nil, err
 	}
 
-	if err = gateClient.authenticateLdap(); err != nil {
+	if err = gateClient.authenticateLdap(flags); err != nil {
 		util.UI.Error("LDAP Authentication Failed")
 		return nil, err
 	}
@@ -467,17 +467,33 @@ func (m *GatewayClient) login(accessToken string) error {
 	return nil
 }
 
-func (m *GatewayClient) authenticateLdap() error {
+func (m *GatewayClient) authenticateLdap(flags *pflag.FlagSet) error {
 	auth := m.Config.Auth
 	if auth != nil && auth.Enabled && auth.Ldap != nil {
-    if auth.Ldap.Username == "" {
-      auth.Ldap.Username = prompt("Username:")
-    }
+		usernameCmd, err := flags.GetString("username")
+		if err != nil {
+			return err
+		}
+		passwordCmd, err := flags.GetString("password")
+		if err != nil {
+			return err
+		}
 
-    if auth.Ldap.Password == "" {
-      auth.Ldap.Password = securePrompt("Password:")
-    }
+		if usernameCmd != "" {
+			auth.Ldap.Username = usernameCmd
+		}
 
+		if passwordCmd != "" {
+			auth.Ldap.Password = passwordCmd
+		}
+
+		if auth.Ldap.Username == "" {
+		  auth.Ldap.Username = prompt("Username:")
+		}
+
+		if auth.Ldap.Password == "" {
+		  auth.Ldap.Password = securePrompt("Password:")
+		}
 
 		if !auth.Ldap.IsValid() {
 			return errors.New("Incorrect LDAP auth configuration. Must include username and password.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,8 @@ type RootOptions struct {
 	color            bool
 	outputFormat     string
 	defaultHeaders   string
+	username		 string
+	password		 string
 }
 
 func Execute(out io.Writer) error {
@@ -42,6 +44,8 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&options.quiet, "quiet", "q", false, "squelch non-essential output")
 	cmd.PersistentFlags().BoolVar(&options.color, "no-color", true, "disable color")
 	cmd.PersistentFlags().StringVar(&options.outputFormat, "output", "", "configure output formatting")
+	cmd.PersistentFlags().StringVar(&options.username, "username", "", "Username")
+	cmd.PersistentFlags().StringVar(&options.password, "password", "", "Password")
 	cmd.PersistentFlags().StringVar(&options.defaultHeaders, "default-headers", "", "configure default headers for gate client as comma separated list (e.g. key1=value1,key2=value2)")
 
 	// create subcommands


### PR DESCRIPTION
Allowing command line params for login simplifies integrations of spin cli in scripts or other wrappers for automation purposes.