### PR TITLE
fix(config) Fixing the ending delimiter for the certificate block in the spin config

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -15,7 +15,7 @@ auth:
     cert: |
       -----BEGIN CERTIFICATE-----
       BLAHBLAHBLAHBLAHBLAHBLAH==
-      -----END RSA PRIVATE KEY-----
+      -----END CERTIFICATE-----
     # Pipe to start a multi-line string. This is necessary to import the b64 cert/key value.
     key: |
       -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
The certificate entry in the sample spin-cli configuration  is delimited with `-----END RSA PRIVATE KEY-----` instead of `-----END CERTIFICATE-----`
