### PR TITLE
feat(cmd): add `account` sub command for querying configured accounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: go
+go:
+  - 1.13.x
 install: ./travisInstall.sh
 script: ./travisBuild.sh

--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -1,0 +1,46 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package account
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+type accountOptions struct {
+}
+
+var (
+	accountShort   = ""
+	accountLong    = ""
+	accountExample = ""
+)
+
+func NewAccountCmd(out io.Writer) *cobra.Command {
+	options := accountOptions{}
+	cmd := &cobra.Command{
+		Use:     "account",
+		Aliases: []string{"account", "acc"},
+		Short:   accountShort,
+		Long:    accountLong,
+		Example: accountExample,
+	}
+
+	// create subcommands
+	cmd.AddCommand(NewGetCmd(options))
+	cmd.AddCommand(NewListCmd(options))
+	return cmd
+}

--- a/cmd/account/get.go
+++ b/cmd/account/get.go
@@ -1,0 +1,82 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package account
+
+import (
+	"fmt"
+	"github.com/spinnaker/spin/util"
+	"net/http"
+
+	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd/gateclient"
+)
+
+type GetOptions struct {
+	*accountOptions
+	expand bool
+}
+
+var (
+	getAccountShort   = "Get the specified account details"
+	getAccountLong    = "Get the specified account details"
+	getAccountExample = "usage: spin account get [options] account-name"
+)
+
+func NewGetCmd(accOptions accountOptions) *cobra.Command {
+	options := GetOptions{
+		accountOptions: &accOptions,
+		expand:         false,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "get",
+		Short:   getAccountShort,
+		Long:    getAccountLong,
+		Example: getAccountExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getAccount(cmd, options, args)
+		},
+	}
+
+	return cmd
+}
+
+func getAccount(cmd *cobra.Command, options GetOptions, args []string) error {
+	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
+	if err != nil {
+		return err
+	}
+
+	accountName, err := util.ReadArgsOrStdin(args)
+	if err != nil {
+		return err
+	}
+
+	account, resp, err := gateClient.CredentialsControllerApi.GetAccountUsingGET(gateClient.Context, accountName, map[string]interface{}{"expand": options.expand})
+	if resp != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Account '%s' not found\n", accountName)
+		} else if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("Encountered an error getting account, status code: %d\n", resp.StatusCode)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+	util.UI.JsonOutput(account, util.UI.OutputFormat)
+
+	return nil
+}

--- a/cmd/account/get.go
+++ b/cmd/account/get.go
@@ -16,16 +16,14 @@ package account
 
 import (
 	"fmt"
-	"github.com/spinnaker/spin/util"
-	"net/http"
-
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
+	"github.com/spinnaker/spin/util"
+	"net/http"
 )
 
 type GetOptions struct {
 	*accountOptions
-	expand bool
 }
 
 var (
@@ -37,7 +35,6 @@ var (
 func NewGetCmd(accOptions accountOptions) *cobra.Command {
 	options := GetOptions{
 		accountOptions: &accOptions,
-		expand:         false,
 	}
 
 	cmd := &cobra.Command{
@@ -64,7 +61,7 @@ func getAccount(cmd *cobra.Command, options GetOptions, args []string) error {
 		return err
 	}
 
-	account, resp, err := gateClient.CredentialsControllerApi.GetAccountUsingGET(gateClient.Context, accountName, map[string]interface{}{"expand": options.expand})
+	account, resp, err := gateClient.CredentialsControllerApi.GetAccountUsingGET(gateClient.Context, accountName, map[string]interface{}{})
 	if resp != nil {
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Account '%s' not found\n", accountName)

--- a/cmd/account/get_test.go
+++ b/cmd/account/get_test.go
@@ -1,0 +1,159 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package account
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/util"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func getRootCmdForTest() *cobra.Command {
+	rootCmd := &cobra.Command{}
+	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
+	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
+	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
+	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
+	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
+	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
+	rootCmd.PersistentFlags().String("default-headers", "", "Configure addtional headers for gate client requests")
+	util.InitUI(false, false, "")
+	return rootCmd
+}
+
+// GateServerFail spins up a local http server that we will configure the GateClient
+// to direct requests to. Responds with a 500 InternalServerError.
+func GateServerFail() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+}
+
+const (
+	ACCOUNT = "account"
+)
+
+func TestAccountGet_basic(t *testing.T) {
+	ts := testGateAccountGetSuccess()
+	defer ts.Close()
+	currentCmd := NewGetCmd(accountOptions{})
+	rootCmd := getRootCmdForTest()
+	accCmd := NewAccountCmd(os.Stdout)
+	accCmd.AddCommand(currentCmd)
+	rootCmd.AddCommand(accCmd)
+
+	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+}
+
+func TestAccountGet_flags(t *testing.T) {
+	ts := testGateAccountGetSuccess()
+	defer ts.Close()
+	currentCmd := NewGetCmd(accountOptions{})
+	rootCmd := getRootCmdForTest()
+	accCmd := NewAccountCmd(os.Stdout)
+	accCmd.AddCommand(currentCmd)
+	rootCmd.AddCommand(accCmd)
+	args := []string{"account", "get", "--gate-endpoint", ts.URL} // Missing positional arg.
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil { // Success is actually failure here, flags are malformed.
+		t.Fatalf("Command failed with: %s", err)
+	}
+}
+
+func TestAccountGet_malformed(t *testing.T) {
+	ts := testGateAccountGetMalformed()
+	defer ts.Close()
+
+	currentCmd := NewGetCmd(accountOptions{})
+	rootCmd := getRootCmdForTest()
+	accCmd := NewAccountCmd(os.Stdout)
+	accCmd.AddCommand(currentCmd)
+	rootCmd.AddCommand(accCmd)
+
+	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil { // Success is actually failure here, return payload is malformed.
+		t.Fatalf("Command failed with: %d", err)
+	}
+}
+
+func TestAccountGet_fail(t *testing.T) {
+	ts := GateServerFail()
+	defer ts.Close()
+
+	currentCmd := NewGetCmd(accountOptions{})
+	rootCmd := getRootCmdForTest()
+	accCmd := NewAccountCmd(os.Stdout)
+	accCmd.AddCommand(currentCmd)
+	rootCmd.AddCommand(accCmd)
+
+	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil { // Success is actually failure here, return payload is malformed.
+		t.Fatalf("Command failed with: %d", err)
+	}
+}
+
+// testGateAccountGetSuccess spins up a local http server that we will configure the GateClient
+// to direct requests to. Responds with a 200 and a well-formed pipeline list.
+func testGateAccountGetSuccess() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(accountJson))
+	}))
+}
+
+// testGateAccountGetMalformed returns a malformed list of pipeline configs.
+func testGateAccountGetMalformed() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(malformedAccountGetJson))
+	}))
+}
+
+const malformedAccountGetJson = `
+ "type": "kubernetes",
+ "providerVersion": "v2",
+ "environment": "self",
+ "skin": "v2",
+ "name": "self",
+ "cloudProvider": "kubernetes",
+ "accountType": "self"
+}
+`
+
+const accountJson = `
+{
+ "type": "kubernetes",
+ "providerVersion": "v2",
+ "environment": "self",
+ "skin": "v2",
+ "name": "account",
+ "cloudProvider": "kubernetes",
+ "accountType": "self"
+}
+`

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -1,0 +1,71 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package account
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd/gateclient"
+	"github.com/spinnaker/spin/util"
+	"net/http"
+)
+
+type ListOptions struct {
+	*accountOptions
+	expand bool
+}
+
+var (
+	listAccountShort   = "List the all accounts"
+	listAccountLong    = "List the all accounts"
+	listAccountExample = "usage: spin account list [options]"
+)
+
+func NewListCmd(accOptions accountOptions) *cobra.Command {
+	options := ListOptions{
+		accountOptions: &accOptions,
+		expand:         false,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   listAccountShort,
+		Long:    listAccountLong,
+		Example: listAccountExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listAccount(cmd, options, args)
+		},
+	}
+	return cmd
+}
+
+func listAccount(cmd *cobra.Command, options ListOptions, args []string) error {
+	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
+	if err != nil {
+		return err
+	}
+	accountList, resp, err := gateClient.CredentialsControllerApi.GetAccountsUsingGET(gateClient.Context, map[string]interface{}{"expand": options.expand})
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Encountered an error listing accounts, status code: %d\n", resp.StatusCode)
+	}
+
+	util.UI.JsonOutput(accountList, util.UI.OutputFormat)
+	return nil
+}

--- a/cmd/account/list_test.go
+++ b/cmd/account/list_test.go
@@ -1,0 +1,127 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package account
+
+import (
+	"fmt"
+	"github.com/spinnaker/spin/util"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestAccountList_basic(t *testing.T) {
+	ts := testGateAccountListSuccess()
+	defer ts.Close()
+
+	currentCmd := NewListCmd(accountOptions{})
+	rootCmd := getRootCmdForTest()
+	accCmd := NewAccountCmd(os.Stdout)
+	accCmd.AddCommand(currentCmd)
+	rootCmd.AddCommand(accCmd)
+
+	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+}
+
+func TestAccountList_malformed(t *testing.T) {
+	ts := testGateAccountListMalformed()
+	defer ts.Close()
+
+	currentCmd := NewListCmd(accountOptions{})
+	rootCmd := getRootCmdForTest()
+	accCmd := NewAccountCmd(os.Stdout)
+	accCmd.AddCommand(currentCmd)
+	rootCmd.AddCommand(accCmd)
+
+	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+}
+
+func TestAccountList_fail(t *testing.T) {
+	ts := GateServerFail()
+	defer ts.Close()
+
+	currentCmd := NewListCmd(accountOptions{})
+	rootCmd := getRootCmdForTest()
+	accCmd := NewAccountCmd(os.Stdout)
+	accCmd.AddCommand(currentCmd)
+	rootCmd.AddCommand(accCmd)
+
+	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+}
+
+func testGateAccountListSuccess() *httptest.Server {
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/credentials/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(accountListJson))
+	}))
+	return httptest.NewServer(mux)
+}
+
+func testGateAccountListMalformed() *httptest.Server {
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/credentials/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(malformedAccountListJson))
+	}))
+	return httptest.NewServer(mux)
+}
+
+const malformedAccountListJson = `
+	{
+	  "type": "kubernetes",
+	  "skin": "v2",
+	  "providerVersion": "v2",
+	  "name": "foobar"
+	 },
+	 {
+	  "type": "dockerRegistry",
+	  "skin": "v1",
+	  "providerVersion": "v1",
+	  "name": "dockerhub"
+	 }
+]
+`
+
+const accountListJson = `[
+{
+  "type": "kubernetes",
+  "skin": "v2",
+  "providerVersion": "v2",
+  "name": "foobar"
+ },
+ {
+  "type": "dockerRegistry",
+  "skin": "v1",
+  "providerVersion": "v1",
+  "name": "dockerhub"
+ }
+]
+`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,13 @@
 package cmd
 
 import (
-	"github.com/spinnaker/spin/cmd/canary"
-	"github.com/spinnaker/spin/cmd/account"
 	"io"
 
 	"github.com/spf13/cobra"
+
+	"github.com/spinnaker/spin/cmd/account"
 	"github.com/spinnaker/spin/cmd/application"
+	"github.com/spinnaker/spin/cmd/canary"
 	"github.com/spinnaker/spin/cmd/pipeline"
 	pipeline_template "github.com/spinnaker/spin/cmd/pipeline-template"
 	"github.com/spinnaker/spin/cmd/project"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/spinnaker/spin/cmd/canary"
+	"github.com/spinnaker/spin/cmd/account"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -50,6 +51,7 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 	cmd.AddCommand(pipeline.NewPipelineCmd(out))
 	cmd.AddCommand(pipeline_template.NewPipelineTemplateCmd(out))
 	cmd.AddCommand(project.NewProjectCmd(out))
+	cmd.AddCommand(account.NewAccountCmd(out))
 
 	return cmd
 }


### PR DESCRIPTION
The `account` subcommand has `get` and `list` commands. Useful for getting all available deployment targets when generating pipelines.