### PR TITLE
chore(builds): Adds GHActions CI for PRs, master, and release branches.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Spin CI
+
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+    - release-*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Install
+      run: go get -d -v
+    - name: Build
+      run: go build -v
+    - name: Test
+      run: go test -v ./...


### PR DESCRIPTION
Followed basic layout from https://github.com/mvdan/github-actions-golang and pulled commands from prexisting Travis CI steps.