### PR TITLE
Add YAML Support

### DIFF
--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -15,8 +15,6 @@
 package account
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +27,7 @@ var (
 	accountExample = ""
 )
 
-func NewAccountCmd(out io.Writer) *cobra.Command {
+func NewAccountCmd() *cobra.Command {
 	options := accountOptions{}
 	cmd := &cobra.Command{
 		Use:     "account",

--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -16,9 +16,11 @@ package account
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd"
 )
 
 type accountOptions struct {
+	*cmd.RootOptions
 }
 
 var (
@@ -27,8 +29,10 @@ var (
 	accountExample = ""
 )
 
-func NewAccountCmd() *cobra.Command {
-	options := accountOptions{}
+func NewAccountCmd(rootOptions *cmd.RootOptions) *cobra.Command {
+	options := &accountOptions{
+		RootOptions: rootOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "account",
 		Aliases: []string{"account", "acc"},

--- a/cmd/account/get.go
+++ b/cmd/account/get.go
@@ -16,10 +16,11 @@ package account
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type GetOptions struct {

--- a/cmd/account/get.go
+++ b/cmd/account/get.go
@@ -74,7 +74,7 @@ func getAccount(cmd *cobra.Command, options GetOptions, args []string) error {
 	if err != nil {
 		return err
 	}
-	util.UI.JsonOutput(account, util.UI.OutputFormat)
+	util.UI.JsonOutput(account)
 
 	return nil
 }

--- a/cmd/account/get.go
+++ b/cmd/account/get.go
@@ -19,11 +19,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type GetOptions struct {
+type getOptions struct {
 	*accountOptions
 }
 
@@ -33,9 +32,9 @@ var (
 	getAccountExample = "usage: spin account get [options] account-name"
 )
 
-func NewGetCmd(accOptions accountOptions) *cobra.Command {
-	options := GetOptions{
-		accountOptions: &accOptions,
+func NewGetCmd(accOptions *accountOptions) *cobra.Command {
+	options := &getOptions{
+		accountOptions: accOptions,
 	}
 
 	cmd := &cobra.Command{
@@ -51,18 +50,13 @@ func NewGetCmd(accOptions accountOptions) *cobra.Command {
 	return cmd
 }
 
-func getAccount(cmd *cobra.Command, options GetOptions, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func getAccount(cmd *cobra.Command, options *getOptions, args []string) error {
 	accountName, err := util.ReadArgsOrStdin(args)
 	if err != nil {
 		return err
 	}
 
-	account, resp, err := gateClient.CredentialsControllerApi.GetAccountUsingGET(gateClient.Context, accountName, map[string]interface{}{})
+	account, resp, err := options.GateClient.CredentialsControllerApi.GetAccountUsingGET(options.GateClient.Context, accountName, map[string]interface{}{})
 	if resp != nil {
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Account '%s' not found\n", accountName)
@@ -74,7 +68,7 @@ func getAccount(cmd *cobra.Command, options GetOptions, args []string) error {
 	if err != nil {
 		return err
 	}
-	util.UI.JsonOutput(account)
+	options.Ui.JsonOutput(account)
 
 	return nil
 }

--- a/cmd/account/get_test.go
+++ b/cmd/account/get_test.go
@@ -16,12 +16,13 @@ package account
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/spinnaker/spin/util"
+	"github.com/spinnaker/spin/cmd"
 )
 
 // GateServerFail spins up a local http server that we will configure the GateClient
@@ -40,15 +41,12 @@ const (
 func TestAccountGet_basic(t *testing.T) {
 	ts := testGateAccountGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd(accountOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd()
-	accCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(accCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(options))
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -57,14 +55,11 @@ func TestAccountGet_basic(t *testing.T) {
 func TestAccountGet_flags(t *testing.T) {
 	ts := testGateAccountGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd(accountOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd()
-	accCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(accCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(options))
 	args := []string{"account", "get", "--gate-endpoint", ts.URL} // Missing positional arg.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil { // Success is actually failure here, flags are malformed.
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -74,15 +69,12 @@ func TestAccountGet_malformed(t *testing.T) {
 	ts := testGateAccountGetMalformed()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(accountOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd()
-	accCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(accCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(options))
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil { // Success is actually failure here, return payload is malformed.
 		t.Fatalf("Command failed with: %d", err)
 	}
@@ -92,15 +84,12 @@ func TestAccountGet_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(accountOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd()
-	accCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(accCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(options))
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil { // Success is actually failure here, return payload is malformed.
 		t.Fatalf("Command failed with: %d", err)
 	}

--- a/cmd/account/get_test.go
+++ b/cmd/account/get_test.go
@@ -15,6 +15,7 @@
 package account
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -22,12 +23,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/andreyvit/diff"
 	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/util"
 )
 
-// GateServerFail spins up a local http server that we will configure the GateClient
+// testGateFail spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 500 InternalServerError.
-func GateServerFail() *httptest.Server {
+func testGateFail() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -38,11 +41,13 @@ const (
 	ACCOUNT = "account"
 )
 
-func TestAccountGet_basic(t *testing.T) {
+func TestAccountGet_json(t *testing.T) {
 	ts := testGateAccountGetSuccess()
 	defer ts.Close()
-	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
-	rootCmd.AddCommand(NewAccountCmd(options))
+
+	buffer := new(bytes.Buffer)
+	rootCmd, rootOpts := cmd.NewCmdRoot(buffer, buffer)
+	rootCmd.AddCommand(NewAccountCmd(rootOpts))
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
@@ -50,13 +55,43 @@ func TestAccountGet_basic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(accountJson)
+	recieved := strings.TrimSpace(buffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected command output:\n%s", diff.LineDiff(expected, recieved))
+	}
+}
+
+func TestAccountGet_yaml(t *testing.T) {
+	ts := testGateAccountGetSuccess()
+	defer ts.Close()
+
+	buffer := new(bytes.Buffer)
+	rootCmd, rootOpts := cmd.NewCmdRoot(buffer, buffer)
+	rootCmd.AddCommand(NewAccountCmd(rootOpts))
+
+	args := []string{"account", "get", ACCOUNT, "--output", "yaml", "--gate-endpoint=" + ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(accountYaml)
+	recieved := strings.TrimSpace(buffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected command output:\n%s", diff.LineDiff(expected, recieved))
+	}
 }
 
 func TestAccountGet_flags(t *testing.T) {
 	ts := testGateAccountGetSuccess()
 	defer ts.Close()
-	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
-	rootCmd.AddCommand(NewAccountCmd(options))
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(rootOpts))
+
 	args := []string{"account", "get", "--gate-endpoint", ts.URL} // Missing positional arg.
 	rootCmd.SetArgs(args)
 	err := rootCmd.Execute()
@@ -69,8 +104,8 @@ func TestAccountGet_malformed(t *testing.T) {
 	ts := testGateAccountGetMalformed()
 	defer ts.Close()
 
-	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
-	rootCmd.AddCommand(NewAccountCmd(options))
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(rootOpts))
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
@@ -81,11 +116,11 @@ func TestAccountGet_malformed(t *testing.T) {
 }
 
 func TestAccountGet_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
-	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
-	rootCmd.AddCommand(NewAccountCmd(options))
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(rootOpts))
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
@@ -98,16 +133,20 @@ func TestAccountGet_fail(t *testing.T) {
 // testGateAccountGetSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 200 and a well-formed pipeline list.
 func testGateAccountGetSuccess() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/credentials/"+ACCOUNT, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, strings.TrimSpace(accountJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 // testGateAccountGetMalformed returns a malformed list of pipeline configs.
 func testGateAccountGetMalformed() *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle("/credentials/"+ACCOUNT, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, strings.TrimSpace(malformedAccountGetJson))
 	}))
+	return httptest.NewServer(mux)
 }
 
 const malformedAccountGetJson = `
@@ -121,14 +160,26 @@ const malformedAccountGetJson = `
 }
 `
 
+//TODO(karlkfi): Why is the json consistently ordered but not alphabetical?
 const accountJson = `
 {
- "type": "kubernetes",
- "providerVersion": "v2",
- "environment": "self",
- "skin": "v2",
  "name": "account",
- "cloudProvider": "kubernetes",
- "accountType": "self"
+ "environment": "self",
+ "providerVersion": "v2",
+ "type": "kubernetes",
+ "skin": "v2",
+ "accountType": "self",
+ "cloudProvider": "kubernetes"
 }
+`
+
+// sorted fields
+const accountYaml = `
+accountType: self
+cloudProvider: kubernetes
+environment: self
+name: account
+providerVersion: v2
+skin: v2
+type: kubernetes
 `

--- a/cmd/account/get_test.go
+++ b/cmd/account/get_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -43,7 +42,7 @@ func TestAccountGet_basic(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewGetCmd(accountOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd(os.Stdout)
+	accCmd := NewAccountCmd()
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
@@ -60,7 +59,7 @@ func TestAccountGet_flags(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewGetCmd(accountOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd(os.Stdout)
+	accCmd := NewAccountCmd()
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 	args := []string{"account", "get", "--gate-endpoint", ts.URL} // Missing positional arg.
@@ -77,7 +76,7 @@ func TestAccountGet_malformed(t *testing.T) {
 
 	currentCmd := NewGetCmd(accountOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd(os.Stdout)
+	accCmd := NewAccountCmd()
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
@@ -95,7 +94,7 @@ func TestAccountGet_fail(t *testing.T) {
 
 	currentCmd := NewGetCmd(accountOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd(os.Stdout)
+	accCmd := NewAccountCmd()
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 

--- a/cmd/account/get_test.go
+++ b/cmd/account/get_test.go
@@ -16,27 +16,14 @@ package account
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/util"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
-)
 
-func getRootCmdForTest() *cobra.Command {
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
-	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
-	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
-	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
-	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
-	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
-	rootCmd.PersistentFlags().String("default-headers", "", "Configure addtional headers for gate client requests")
-	util.InitUI(false, false, "")
-	return rootCmd
-}
+	"github.com/spinnaker/spin/util"
+)
 
 // GateServerFail spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 500 InternalServerError.
@@ -55,14 +42,14 @@ func TestAccountGet_basic(t *testing.T) {
 	ts := testGateAccountGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd(accountOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	accCmd := NewAccountCmd(os.Stdout)
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -72,13 +59,13 @@ func TestAccountGet_flags(t *testing.T) {
 	ts := testGateAccountGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd(accountOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	accCmd := NewAccountCmd(os.Stdout)
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 	args := []string{"account", "get", "--gate-endpoint", ts.URL} // Missing positional arg.
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil { // Success is actually failure here, flags are malformed.
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -89,14 +76,14 @@ func TestAccountGet_malformed(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(accountOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	accCmd := NewAccountCmd(os.Stdout)
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil { // Success is actually failure here, return payload is malformed.
 		t.Fatalf("Command failed with: %d", err)
 	}
@@ -107,14 +94,14 @@ func TestAccountGet_fail(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(accountOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	accCmd := NewAccountCmd(os.Stdout)
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
 	args := []string{"account", "get", ACCOUNT, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil { // Success is actually failure here, return payload is malformed.
 		t.Fatalf("Command failed with: %d", err)
 	}

--- a/cmd/account/get_test.go
+++ b/cmd/account/get_test.go
@@ -160,7 +160,10 @@ const malformedAccountGetJson = `
 }
 `
 
-//TODO(karlkfi): Why is the json consistently ordered but not alphabetical?
+// Weirdly sorted ordering matches AccountDetails object field order,
+// which is directly from the Swagger API definition.
+// See: gateapi/account_details.go
+// TODO(karlkfi): sort alphabetically. I doubt anyone depends on the order.
 const accountJson = `
 {
  "name": "account",

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -16,10 +16,11 @@ package account
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type ListOptions struct {

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -19,11 +19,9 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 )
 
-type ListOptions struct {
+type listOptions struct {
 	*accountOptions
 	expand bool
 }
@@ -34,9 +32,9 @@ var (
 	listAccountExample = "usage: spin account list [options]"
 )
 
-func NewListCmd(accOptions accountOptions) *cobra.Command {
-	options := ListOptions{
-		accountOptions: &accOptions,
+func NewListCmd(accOptions *accountOptions) *cobra.Command {
+	options := &listOptions{
+		accountOptions: accOptions,
 		expand:         false,
 	}
 
@@ -53,12 +51,8 @@ func NewListCmd(accOptions accountOptions) *cobra.Command {
 	return cmd
 }
 
-func listAccount(cmd *cobra.Command, options ListOptions, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-	accountList, resp, err := gateClient.CredentialsControllerApi.GetAccountsUsingGET(gateClient.Context, map[string]interface{}{"expand": options.expand})
+func listAccount(cmd *cobra.Command, options *listOptions, args []string) error {
+	accountList, resp, err := options.GateClient.CredentialsControllerApi.GetAccountsUsingGET(options.GateClient.Context, map[string]interface{}{"expand": options.expand})
 	if err != nil {
 		return err
 	}
@@ -67,6 +61,6 @@ func listAccount(cmd *cobra.Command, options ListOptions, args []string) error {
 		return fmt.Errorf("Encountered an error listing accounts, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(accountList)
+	options.Ui.JsonOutput(accountList)
 	return nil
 }

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -67,6 +67,6 @@ func listAccount(cmd *cobra.Command, options ListOptions, args []string) error {
 		return fmt.Errorf("Encountered an error listing accounts, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(accountList, util.UI.OutputFormat)
+	util.UI.JsonOutput(accountList)
 	return nil
 }

--- a/cmd/account/list_test.go
+++ b/cmd/account/list_test.go
@@ -29,14 +29,14 @@ func TestAccountList_basic(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewListCmd(accountOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	accCmd := NewAccountCmd(os.Stdout)
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
 	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -47,14 +47,14 @@ func TestAccountList_malformed(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewListCmd(accountOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	accCmd := NewAccountCmd(os.Stdout)
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
 	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,14 +65,14 @@ func TestAccountList_fail(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewListCmd(accountOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	accCmd := NewAccountCmd(os.Stdout)
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
 	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/account/list_test.go
+++ b/cmd/account/list_test.go
@@ -16,12 +16,13 @@ package account
 
 import (
 	"fmt"
-	"github.com/spinnaker/spin/util"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestAccountList_basic(t *testing.T) {

--- a/cmd/account/list_test.go
+++ b/cmd/account/list_test.go
@@ -57,7 +57,7 @@ func TestAccountList_malformed(t *testing.T) {
 }
 
 func TestAccountList_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)

--- a/cmd/account/list_test.go
+++ b/cmd/account/list_test.go
@@ -16,11 +16,13 @@ package account
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,15 +30,12 @@ func TestAccountList_basic(t *testing.T) {
 	ts := testGateAccountListSuccess()
 	defer ts.Close()
 
-	currentCmd := NewListCmd(accountOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd()
-	accCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(accCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(options))
 
 	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -46,15 +45,12 @@ func TestAccountList_malformed(t *testing.T) {
 	ts := testGateAccountListMalformed()
 	defer ts.Close()
 
-	currentCmd := NewListCmd(accountOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd()
-	accCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(accCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(options))
 
 	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -64,15 +60,12 @@ func TestAccountList_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	currentCmd := NewListCmd(accountOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd()
-	accCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(accCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewAccountCmd(options))
 
 	args := []string{"account", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/account/list_test.go
+++ b/cmd/account/list_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestAccountList_basic(t *testing.T) {
 
 	currentCmd := NewListCmd(accountOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd(os.Stdout)
+	accCmd := NewAccountCmd()
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
@@ -49,7 +48,7 @@ func TestAccountList_malformed(t *testing.T) {
 
 	currentCmd := NewListCmd(accountOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd(os.Stdout)
+	accCmd := NewAccountCmd()
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 
@@ -67,7 +66,7 @@ func TestAccountList_fail(t *testing.T) {
 
 	currentCmd := NewListCmd(accountOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	accCmd := NewAccountCmd(os.Stdout)
+	accCmd := NewAccountCmd()
 	accCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(accCmd)
 

--- a/cmd/application/application.go
+++ b/cmd/application/application.go
@@ -2,9 +2,11 @@ package application
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd"
 )
 
 type applicationOptions struct {
+	*cmd.RootOptions
 }
 
 var (
@@ -13,8 +15,10 @@ var (
 	applicationExample = ""
 )
 
-func NewApplicationCmd() *cobra.Command {
-	options := applicationOptions{}
+func NewApplicationCmd(rootOptions *cmd.RootOptions) *cobra.Command {
+	options := &applicationOptions{
+		RootOptions: rootOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "application",
 		Aliases: []string{"applications", "app"},

--- a/cmd/application/application.go
+++ b/cmd/application/application.go
@@ -1,8 +1,6 @@
 package application
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +13,7 @@ var (
 	applicationExample = ""
 )
 
-func NewApplicationCmd(out io.Writer) *cobra.Command {
+func NewApplicationCmd() *cobra.Command {
 	options := applicationOptions{}
 	cmd := &cobra.Command{
 		Use:     "application",

--- a/cmd/application/delete.go
+++ b/cmd/application/delete.go
@@ -21,11 +21,10 @@ import (
 	orca_tasks "github.com/spinnaker/spin/cmd/orca-tasks"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type DeleteOptions struct {
+type deleteOptions struct {
 	*applicationOptions
 }
 
@@ -35,24 +34,24 @@ var (
 	deleteApplicationExample = "usage: spin application delete [options] applicationName"
 )
 
-func NewDeleteCmd(appOptions applicationOptions) *cobra.Command {
+func NewDeleteCmd(appOptions *applicationOptions) *cobra.Command {
+	options := &deleteOptions{
+		appOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "delete",
 		Aliases: []string{"del"},
 		Short:   deleteApplicationShort,
 		Long:    deleteApplicationLong,
 		Example: deleteApplicationExample,
-		RunE:    deleteApplication,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return deleteApplication(cmd, options, args)
+		},
 	}
 	return cmd
 }
 
-func deleteApplication(cmd *cobra.Command, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func deleteApplication(cmd *cobra.Command, options *deleteOptions, args []string) error {
 	applicationName, err := util.ReadArgsOrStdin(args)
 	if err != nil {
 		return err
@@ -65,7 +64,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	_, resp, err := gateClient.ApplicationControllerApi.GetApplicationUsingGET(gateClient.Context, applicationName, map[string]interface{}{"expand": false})
+	_, resp, err := options.GateClient.ApplicationControllerApi.GetApplicationUsingGET(options.GateClient.Context, applicationName, map[string]interface{}{"expand": false})
 
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("Attempting to delete application '%s' which does not exist, exiting...", applicationName)
@@ -81,7 +80,7 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		"description": fmt.Sprintf("Delete Application: %s", applicationName),
 	}
 
-	taskRef, resp, err := gateClient.TaskControllerApi.TaskUsingPOST1(gateClient.Context, deleteAppTask)
+	taskRef, resp, err := options.GateClient.TaskControllerApi.TaskUsingPOST1(options.GateClient.Context, deleteAppTask)
 	if err != nil {
 		return err
 	}
@@ -89,11 +88,11 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Encountered an error deleting application, status code: %d\n", resp.StatusCode)
 	}
 
-	err = orca_tasks.WaitForSuccessfulTask(gateClient, taskRef, 5)
+	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, taskRef, 5)
 	if err != nil {
 		return err
 	}
 
-	util.UI.Output("Application deleted")
+	options.Ui.Output("Application deleted")
 	return nil
 }

--- a/cmd/application/delete.go
+++ b/cmd/application/delete.go
@@ -93,6 +93,6 @@ func deleteApplication(cmd *cobra.Command, options *deleteOptions, args []string
 		return err
 	}
 
-	options.Ui.Output("Application deleted")
+	options.Ui.Success("Application deleted")
 	return nil
 }

--- a/cmd/application/delete.go
+++ b/cmd/application/delete.go
@@ -16,8 +16,9 @@ package application
 
 import (
 	"fmt"
-	"github.com/spinnaker/spin/cmd/orca-tasks"
 	"net/http"
+
+	orca_tasks "github.com/spinnaker/spin/cmd/orca-tasks"
 
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"

--- a/cmd/application/delete.go
+++ b/cmd/application/delete.go
@@ -94,6 +94,6 @@ func deleteApplication(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	util.UI.Output(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Application deleted")))
+	util.UI.Output("Application deleted")
 	return nil
 }

--- a/cmd/application/delete_test.go
+++ b/cmd/application/delete_test.go
@@ -30,14 +30,14 @@ func TestApplicationDelete_basic(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewDeleteCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "delete", NAME, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -48,14 +48,14 @@ func TestApplicationDelete_fail(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewDeleteCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "delete", NAME, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -66,14 +66,14 @@ func TestApplicationDelete_flags(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewDeleteCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "delete", NAME, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/application/delete_test.go
+++ b/cmd/application/delete_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/spinnaker/spin/util"
@@ -31,7 +30,7 @@ func TestApplicationDelete_basic(t *testing.T) {
 
 	currentCmd := NewDeleteCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -49,7 +48,7 @@ func TestApplicationDelete_fail(t *testing.T) {
 
 	currentCmd := NewDeleteCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -67,7 +66,7 @@ func TestApplicationDelete_flags(t *testing.T) {
 
 	currentCmd := NewDeleteCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 

--- a/cmd/application/delete_test.go
+++ b/cmd/application/delete_test.go
@@ -17,10 +17,12 @@ package application
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,15 +30,12 @@ func TestApplicationDelete_basic(t *testing.T) {
 	ts := testGateApplicationDeleteSuccess()
 	defer ts.Close()
 
-	currentCmd := NewDeleteCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "delete", NAME, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -46,15 +45,12 @@ func TestApplicationDelete_fail(t *testing.T) {
 	ts := GateAppDeleteFail()
 	defer ts.Close()
 
-	currentCmd := NewDeleteCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "delete", NAME, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -64,15 +60,12 @@ func TestApplicationDelete_flags(t *testing.T) {
 	ts := testGateApplicationDeleteSuccess()
 	defer ts.Close()
 
-	currentCmd := NewDeleteCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "delete", NAME, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/application/get.go
+++ b/cmd/application/get.go
@@ -16,8 +16,9 @@ package application
 
 import (
 	"fmt"
-	"github.com/spinnaker/spin/util"
 	"net/http"
+
+	"github.com/spinnaker/spin/util"
 
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
@@ -37,7 +38,7 @@ var (
 func NewGetCmd(appOptions applicationOptions) *cobra.Command {
 	options := GetOptions{
 		applicationOptions: &appOptions,
-		expand: false,
+		expand:             false,
 	}
 
 	cmd := &cobra.Command{
@@ -46,7 +47,7 @@ func NewGetCmd(appOptions applicationOptions) *cobra.Command {
 		Short:   getApplicationShort,
 		Long:    getApplicationLong,
 		Example: getApplicationExample,
-		RunE:    func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			return getApplication(cmd, options, args)
 		},
 	}

--- a/cmd/application/get.go
+++ b/cmd/application/get.go
@@ -85,10 +85,10 @@ func getApplication(cmd *cobra.Command, options GetOptions, args []string) error
 	if options.expand {
 		// NOTE: expand returns the actual attributes as well as the app's cluster details, nested in
 		// their own fields. This means that the expanded output can't be submitted as input to `save`.
-		util.UI.JsonOutput(app, util.UI.OutputFormat)
+		util.UI.JsonOutput(app)
 	} else {
 		// NOTE: app GET wraps the actual app attributes in an 'attributes' field.
-		util.UI.JsonOutput(app["attributes"], util.UI.OutputFormat)
+		util.UI.JsonOutput(app["attributes"])
 	}
 
 	return nil

--- a/cmd/application/get_test.go
+++ b/cmd/application/get_test.go
@@ -16,12 +16,13 @@ package application
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/spinnaker/spin/util"
+	"github.com/spinnaker/spin/cmd"
 )
 
 const (
@@ -31,15 +32,13 @@ const (
 func TestApplicationGet_basic(t *testing.T) {
 	ts := testGateApplicationGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "get", APP, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -48,14 +47,13 @@ func TestApplicationGet_basic(t *testing.T) {
 func TestApplicationGet_flags(t *testing.T) {
 	ts := testGateApplicationGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
+
 	args := []string{"application", "get", "--gate-endpoint", ts.URL} // Missing positional arg.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil { // Success is actually failure here, flags are malformed.
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,15 +63,12 @@ func TestApplicationGet_malformed(t *testing.T) {
 	ts := testGateApplicationGetMalformed()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "get", APP, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil { // Success is actually failure here, return payload is malformed.
 		t.Fatalf("Command failed with: %d", err)
 	}
@@ -83,15 +78,12 @@ func TestApplicationGet_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "get", APP, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil { // Success is actually failure here, return payload is malformed.
 		t.Fatalf("Command failed with: %d", err)
 	}

--- a/cmd/application/get_test.go
+++ b/cmd/application/get_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -34,7 +33,7 @@ func TestApplicationGet_basic(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewGetCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -51,7 +50,7 @@ func TestApplicationGet_flags(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewGetCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 	args := []string{"application", "get", "--gate-endpoint", ts.URL} // Missing positional arg.
@@ -68,7 +67,7 @@ func TestApplicationGet_malformed(t *testing.T) {
 
 	currentCmd := NewGetCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -86,7 +85,7 @@ func TestApplicationGet_fail(t *testing.T) {
 
 	currentCmd := NewGetCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 

--- a/cmd/application/get_test.go
+++ b/cmd/application/get_test.go
@@ -23,39 +23,24 @@ import (
 	"testing"
 
 	"github.com/spinnaker/spin/util"
-
-	"github.com/spf13/cobra"
 )
 
 const (
 	APP = "app"
 )
 
-func getRootCmdForTest() *cobra.Command {
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
-	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
-	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
-	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
-	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
-	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
-	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
-	util.InitUI(false, false, "")
-	return rootCmd
-}
-
 func TestApplicationGet_basic(t *testing.T) {
 	ts := testGateApplicationGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "get", APP, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,13 +50,13 @@ func TestApplicationGet_flags(t *testing.T) {
 	ts := testGateApplicationGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 	args := []string{"application", "get", "--gate-endpoint", ts.URL} // Missing positional arg.
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil { // Success is actually failure here, flags are malformed.
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -82,14 +67,14 @@ func TestApplicationGet_malformed(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "get", APP, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil { // Success is actually failure here, return payload is malformed.
 		t.Fatalf("Command failed with: %d", err)
 	}
@@ -100,14 +85,14 @@ func TestApplicationGet_fail(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "get", APP, "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil { // Success is actually failure here, return payload is malformed.
 		t.Fatalf("Command failed with: %d", err)
 	}

--- a/cmd/application/list.go
+++ b/cmd/application/list.go
@@ -59,6 +59,6 @@ func listApplication(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Encountered an error saving application, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(appList, util.UI.OutputFormat)
+	util.UI.JsonOutput(appList)
 	return nil
 }

--- a/cmd/application/list.go
+++ b/cmd/application/list.go
@@ -19,11 +19,9 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 )
 
-type ListOptions struct {
+type listOptions struct {
 	*applicationOptions
 }
 
@@ -33,24 +31,25 @@ var (
 	listApplicationExample = "usage: spin application list [options]"
 )
 
-func NewListCmd(appOptions applicationOptions) *cobra.Command {
+func NewListCmd(appOptions *applicationOptions) *cobra.Command {
+	options := &listOptions{
+		applicationOptions: appOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   listApplicationShort,
 		Long:    listApplicationLong,
 		Example: listApplicationExample,
-		RunE:    listApplication,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listApplication(cmd, options, args)
+		},
 	}
 	return cmd
 }
 
-func listApplication(cmd *cobra.Command, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-	appList, resp, err := gateClient.ApplicationControllerApi.GetAllApplicationsUsingGET(gateClient.Context, map[string]interface{}{})
+func listApplication(cmd *cobra.Command, options *listOptions, args []string) error {
+	appList, resp, err := options.GateClient.ApplicationControllerApi.GetAllApplicationsUsingGET(options.GateClient.Context, map[string]interface{}{})
 	if err != nil {
 		return err
 	}
@@ -59,6 +58,6 @@ func listApplication(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Encountered an error saving application, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(appList)
+	options.Ui.JsonOutput(appList)
 	return nil
 }

--- a/cmd/application/list_test.go
+++ b/cmd/application/list_test.go
@@ -30,14 +30,14 @@ func TestApplicationList_basic(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewListCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -48,14 +48,14 @@ func TestApplicationList_malformed(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewListCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -66,14 +66,14 @@ func TestApplicationList_fail(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewListCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	args := []string{"application", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/application/list_test.go
+++ b/cmd/application/list_test.go
@@ -16,11 +16,13 @@ package application
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,15 +30,12 @@ func TestApplicationList_basic(t *testing.T) {
 	ts := testGateApplicationList(false)
 	defer ts.Close()
 
-	currentCmd := NewListCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -46,15 +45,12 @@ func TestApplicationList_malformed(t *testing.T) {
 	ts := testGateApplicationList(true)
 	defer ts.Close()
 
-	currentCmd := NewListCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -64,15 +60,12 @@ func TestApplicationList_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	currentCmd := NewListCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{"application", "list", "--gate-endpoint=" + ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/application/list_test.go
+++ b/cmd/application/list_test.go
@@ -57,7 +57,7 @@ func TestApplicationList_malformed(t *testing.T) {
 }
 
 func TestApplicationList_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)

--- a/cmd/application/list_test.go
+++ b/cmd/application/list_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestApplicationList_basic(t *testing.T) {
 
 	currentCmd := NewListCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -49,7 +48,7 @@ func TestApplicationList_malformed(t *testing.T) {
 
 	currentCmd := NewListCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -67,7 +66,7 @@ func TestApplicationList_fail(t *testing.T) {
 
 	currentCmd := NewListCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 

--- a/cmd/application/save.go
+++ b/cmd/application/save.go
@@ -49,8 +49,8 @@ func NewSaveCmd(appOptions applicationOptions) *cobra.Command {
 			return saveApplication(cmd, options)
 		},
 	}
-	cmd.PersistentFlags().StringVarP(&options.applicationFile, "file", "", "", "path to the application file")
-	cmd.PersistentFlags().StringVarP(&options.applicationName, "application-name", "", "", "name of the application")
+	cmd.PersistentFlags().StringVarP(&options.applicationFile, "file", "f", "", "path to the application file")
+	cmd.PersistentFlags().StringVarP(&options.applicationName, "application-name", "a", "", "name of the application")
 	cmd.PersistentFlags().StringVarP(&options.ownerEmail, "owner-email", "", "", "email of the application owner")
 	options.cloudProviders = cmd.PersistentFlags().StringArrayP("cloud-providers", "", []string{}, "cloud providers configured for this application")
 

--- a/cmd/application/save.go
+++ b/cmd/application/save.go
@@ -117,6 +117,6 @@ func saveApplication(cmd *cobra.Command, options SaveOptions) error {
 		return err
 	}
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Application save succeeded")))
+	util.UI.Success("Application save succeeded")
 	return nil
 }

--- a/cmd/application/save.go
+++ b/cmd/application/save.go
@@ -17,11 +17,12 @@ package application
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/cmd/orca-tasks"
+	orca_tasks "github.com/spinnaker/spin/cmd/orca-tasks"
 	"github.com/spinnaker/spin/util"
-	"strings"
 )
 
 type SaveOptions struct {
@@ -33,8 +34,8 @@ type SaveOptions struct {
 }
 
 var (
-	saveApplicationShort   = "Save the provided application"
-	saveApplicationLong    = "Save the specified application"
+	saveApplicationShort = "Save the provided application"
+	saveApplicationLong  = "Save the specified application"
 )
 
 func NewSaveCmd(appOptions applicationOptions) *cobra.Command {
@@ -42,9 +43,9 @@ func NewSaveCmd(appOptions applicationOptions) *cobra.Command {
 		applicationOptions: &appOptions,
 	}
 	cmd := &cobra.Command{
-		Use:     "save",
-		Short:   saveApplicationShort,
-		Long:    saveApplicationLong,
+		Use:   "save",
+		Short: saveApplicationShort,
+		Long:  saveApplicationLong,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return saveApplication(cmd, options)
 		},

--- a/cmd/application/save_test.go
+++ b/cmd/application/save_test.go
@@ -36,7 +36,7 @@ func TestApplicationSave_basic(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewSaveCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -66,7 +66,7 @@ func TestApplicationSave_fail(t *testing.T) {
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -87,7 +87,7 @@ func TestApplicationSave_flags(t *testing.T) {
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -110,7 +110,7 @@ func TestApplicationSave_missingname(t *testing.T) {
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -133,7 +133,7 @@ func TestApplicationSave_missingemail(t *testing.T) {
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -156,7 +156,7 @@ func TestApplicationSave_missingproviders(t *testing.T) {
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -185,7 +185,7 @@ func TestApplicationSave_filebasic(t *testing.T) {
 
 	currentCmd := NewSaveCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
@@ -219,7 +219,7 @@ func TestApplicationSave_stdinbasic(t *testing.T) {
 
 	currentCmd := NewSaveCmd(applicationOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd(os.Stdout)
+	appCmd := NewApplicationCmd()
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 

--- a/cmd/application/save_test.go
+++ b/cmd/application/save_test.go
@@ -35,7 +35,7 @@ func TestApplicationSave_basic(t *testing.T) {
 	ts := testGateApplicationSaveSuccess()
 	defer ts.Close()
 	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
@@ -48,7 +48,7 @@ func TestApplicationSave_basic(t *testing.T) {
 		"--cloud-providers", "gce,kubernetes",
 	}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,13 +65,13 @@ func TestApplicationSave_fail(t *testing.T) {
 		"--gate-endpoint=" + ts.URL,
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -86,13 +86,13 @@ func TestApplicationSave_flags(t *testing.T) {
 		"--gate-endpoint=" + ts.URL,
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -109,13 +109,13 @@ func TestApplicationSave_missingname(t *testing.T) {
 		"--gate-endpoint=" + ts.URL,
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -132,13 +132,13 @@ func TestApplicationSave_missingemail(t *testing.T) {
 		"--gate-endpoint", ts.URL,
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -155,13 +155,13 @@ func TestApplicationSave_missingproviders(t *testing.T) {
 		"--gate-endpoint", ts.URL,
 	}
 	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -184,13 +184,13 @@ func TestApplicationSave_filebasic(t *testing.T) {
 	}
 
 	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -218,13 +218,13 @@ func TestApplicationSave_stdinbasic(t *testing.T) {
 	}
 
 	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	appCmd := NewApplicationCmd(os.Stdout)
 	appCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(appCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/application/save_test.go
+++ b/cmd/application/save_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -34,11 +35,9 @@ const (
 func TestApplicationSave_basic(t *testing.T) {
 	ts := testGateApplicationSaveSuccess()
 	defer ts.Close()
-	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
 
 	args := []string{
 		"application", "save",
@@ -48,7 +47,7 @@ func TestApplicationSave_basic(t *testing.T) {
 		"--cloud-providers", "gce,kubernetes",
 	}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -57,6 +56,10 @@ func TestApplicationSave_basic(t *testing.T) {
 func TestApplicationSave_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
+
 	args := []string{
 		"application", "save",
 		"--application-name", NAME,
@@ -64,14 +67,8 @@ func TestApplicationSave_fail(t *testing.T) {
 		"--cloud-providers", "gce,kubernetes",
 		"--gate-endpoint=" + ts.URL,
 	}
-	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -81,18 +78,15 @@ func TestApplicationSave_flags(t *testing.T) {
 	ts := testGateApplicationSaveSuccess()
 	defer ts.Close()
 
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
+
 	args := []string{
 		"application", "save",
 		"--gate-endpoint=" + ts.URL,
 	}
-	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -102,20 +96,17 @@ func TestApplicationSave_missingname(t *testing.T) {
 	ts := testGateApplicationSaveSuccess()
 	defer ts.Close()
 
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
+
 	args := []string{
 		"application", "save",
 		"--owner-email", EMAIL,
 		"--cloud-providers", "gce,kubernetes",
 		"--gate-endpoint=" + ts.URL,
 	}
-	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -125,20 +116,17 @@ func TestApplicationSave_missingemail(t *testing.T) {
 	ts := testGateApplicationSaveSuccess()
 	defer ts.Close()
 
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
+
 	args := []string{
 		"application", "save",
 		"--application-name", NAME,
 		"--cloud-providers", "gce,kubernetes",
 		"--gate-endpoint", ts.URL,
 	}
-	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -148,20 +136,17 @@ func TestApplicationSave_missingproviders(t *testing.T) {
 	ts := testGateApplicationSaveSuccess()
 	defer ts.Close()
 
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
+
 	args := []string{
 		"application", "save",
 		"--application-name", NAME,
 		"--owner-email", EMAIL,
 		"--gate-endpoint", ts.URL,
 	}
-	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -177,20 +162,16 @@ func TestApplicationSave_filebasic(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
+
 	args := []string{
 		"application", "save",
 		"--file", tempFile.Name(),
 		"--gate-endpoint", ts.URL,
 	}
-
-	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -206,25 +187,22 @@ func TestApplicationSave_stdinbasic(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
+	//TODO(karlkfi): Pipe input writer through NewCmdRoot
 	// Prepare Stdin for test reading.
 	tempFile.Seek(0, 0)
 	oldStdin := os.Stdin
 	defer func() { os.Stdin = oldStdin }()
 	os.Stdin = tempFile
 
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewApplicationCmd(options))
+
 	args := []string{
 		"application", "save",
 		"--gate-endpoint", ts.URL,
 	}
-
-	currentCmd := NewSaveCmd(applicationOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	appCmd := NewApplicationCmd()
-	appCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(appCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/assembler/assembler.go
+++ b/cmd/assembler/assembler.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2018, Google, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package assembler
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/account"
+	"github.com/spinnaker/spin/cmd/application"
+	"github.com/spinnaker/spin/cmd/canary"
+	canary_config "github.com/spinnaker/spin/cmd/canary/canary-config"
+	"github.com/spinnaker/spin/cmd/pipeline"
+	pipeline_template "github.com/spinnaker/spin/cmd/pipeline-template"
+	"github.com/spinnaker/spin/cmd/pipeline/execution"
+	"github.com/spinnaker/spin/cmd/project"
+)
+
+// AddSubCommands adds all the subcommands to the rootCmd.
+// rootOpts are passed through to the subcommands.
+func AddSubCommands(rootCmd *cobra.Command, rootOpts *cmd.RootOptions) {
+	rootCmd.AddCommand(account.NewAccountCmd(rootOpts))
+
+	rootCmd.AddCommand(application.NewApplicationCmd(rootOpts))
+
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(canary_config.NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
+
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(execution.NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
+
+	rootCmd.AddCommand(pipeline_template.NewPipelineTemplateCmd(rootOpts))
+
+	rootCmd.AddCommand(project.NewProjectCmd(rootOpts))
+}

--- a/cmd/canary/canary-config/canary_config.go
+++ b/cmd/canary/canary-config/canary_config.go
@@ -15,8 +15,9 @@
 package canary_config
 
 import (
-	"github.com/spf13/cobra"
 	"io"
+
+	"github.com/spf13/cobra"
 )
 
 type canaryConfigOptions struct{}

--- a/cmd/canary/canary-config/canary_config.go
+++ b/cmd/canary/canary-config/canary_config.go
@@ -16,9 +16,12 @@ package canary_config
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd/canary"
 )
 
-type canaryConfigOptions struct{}
+type canaryConfigOptions struct {
+	*canary.CanaryOptions
+}
 
 const (
 	canaryConfigShort   = ""
@@ -26,8 +29,10 @@ const (
 	canaryConfigExample = ""
 )
 
-func NewCanaryConfigCmd() *cobra.Command {
-	options := canaryConfigOptions{}
+func NewCanaryConfigCmd(canaryOptions *canary.CanaryOptions) *cobra.Command {
+	options := &canaryConfigOptions{
+		CanaryOptions: canaryOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "canary-config",
 		Aliases: []string{"canary-configs", "cc"},
@@ -37,7 +42,7 @@ func NewCanaryConfigCmd() *cobra.Command {
 	}
 
 	// create subcommands
-	cmd.AddCommand(NewDeleteCmd())
+	cmd.AddCommand(NewDeleteCmd(options))
 	cmd.AddCommand(NewGetCmd(options))
 	cmd.AddCommand(NewListCmd(options))
 	cmd.AddCommand(NewSaveCmd(options))

--- a/cmd/canary/canary-config/canary_config.go
+++ b/cmd/canary/canary-config/canary_config.go
@@ -15,8 +15,6 @@
 package canary_config
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +26,7 @@ const (
 	canaryConfigExample = ""
 )
 
-func NewCanaryConfigCmd(out io.Writer) *cobra.Command {
+func NewCanaryConfigCmd() *cobra.Command {
 	options := canaryConfigOptions{}
 	cmd := &cobra.Command{
 		Use:     "canary-config",

--- a/cmd/canary/canary-config/delete.go
+++ b/cmd/canary/canary-config/delete.go
@@ -19,11 +19,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type DeleteOptions struct {
+type deleteOptions struct {
 	*canaryConfigOptions
 }
 
@@ -32,33 +31,31 @@ const (
 	deleteCanaryConfigLong  = "Delete the provided canary config"
 )
 
-func NewDeleteCmd() *cobra.Command {
+func NewDeleteCmd(canaryConfigOptions *canaryConfigOptions) *cobra.Command {
+	options := &deleteOptions{
+		canaryConfigOptions: canaryConfigOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "delete",
 		Aliases: []string{"del"},
 		Short:   deleteCanaryConfigShort,
 		Long:    deleteCanaryConfigLong,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return deleteCanaryConfig(cmd, args)
+			return deleteCanaryConfig(cmd, options, args)
 		},
 	}
 
 	return cmd
 }
 
-func deleteCanaryConfig(cmd *cobra.Command, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func deleteCanaryConfig(cmd *cobra.Command, options *deleteOptions, args []string) error {
 	id, err := util.ReadArgsOrStdin(args)
 	if err != nil {
 		return err
 	}
 
-	resp, err := gateClient.V2CanaryConfigControllerApi.DeleteCanaryConfigUsingDELETE(
-		gateClient.Context, id, map[string]interface{}{})
+	resp, err := options.GateClient.V2CanaryConfigControllerApi.DeleteCanaryConfigUsingDELETE(
+		options.GateClient.Context, id, map[string]interface{}{})
 
 	if err != nil {
 		return err
@@ -69,6 +66,6 @@ func deleteCanaryConfig(cmd *cobra.Command, args []string) error {
 			"Encountered an error deleting canary config, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.Success(fmt.Sprintf("Canary config %s deleted", id))
+	options.Ui.Success(fmt.Sprintf("Canary config %s deleted", id))
 	return nil
 }

--- a/cmd/canary/canary-config/delete.go
+++ b/cmd/canary/canary-config/delete.go
@@ -16,10 +16,11 @@ package canary_config
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type DeleteOptions struct {

--- a/cmd/canary/canary-config/delete.go
+++ b/cmd/canary/canary-config/delete.go
@@ -69,7 +69,6 @@ func deleteCanaryConfig(cmd *cobra.Command, args []string) error {
 			"Encountered an error deleting canary config, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.Info(
-		util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Canary config %s deleted", id)))
+	util.UI.Success(fmt.Sprintf("Canary config %s deleted", id))
 	return nil
 }

--- a/cmd/canary/canary-config/delete_test.go
+++ b/cmd/canary/canary-config/delete_test.go
@@ -17,7 +17,6 @@ package canary_config
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/spinnaker/spin/util"
@@ -30,7 +29,7 @@ func TestCanaryConfigDelete_basic(t *testing.T) {
 	args := []string{"canary-config", "delete", "configId", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd()
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -48,7 +47,7 @@ func TestCanaryConfigDelete_fail(t *testing.T) {
 	args := []string{"canary-config", "delete", "configId", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd()
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -66,7 +65,7 @@ func TestCanaryConfigDelete_missingid(t *testing.T) {
 	args := []string{"canary-config", "delete", "--gate-endpoint", ts.URL} // Missing cc id.
 	currentCmd := NewDeleteCmd()
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 

--- a/cmd/canary/canary-config/delete_test.go
+++ b/cmd/canary/canary-config/delete_test.go
@@ -15,11 +15,12 @@
 package canary_config
 
 import (
-	"github.com/spinnaker/spin/util"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestCanaryConfigDelete_basic(t *testing.T) {

--- a/cmd/canary/canary-config/delete_test.go
+++ b/cmd/canary/canary-config/delete_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestCanaryConfigDelete_basic(t *testing.T) {
-	ts := gateServerDeleteSuccess()
+	ts := testGateDeleteSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -43,7 +43,7 @@ func TestCanaryConfigDelete_basic(t *testing.T) {
 }
 
 func TestCanaryConfigDelete_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -60,7 +60,7 @@ func TestCanaryConfigDelete_fail(t *testing.T) {
 }
 
 func TestCanaryConfigDelete_missingid(t *testing.T) {
-	ts := gateServerDeleteSuccess()
+	ts := testGateDeleteSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -76,9 +76,9 @@ func TestCanaryConfigDelete_missingid(t *testing.T) {
 	}
 }
 
-// gateServerDeleteSuccess spins up a local http server that we will configure the GateClient
+// testGateDeleteSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to.
-func gateServerDeleteSuccess() *httptest.Server {
+func testGateDeleteSuccess() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/v2/canaryConfig/configId", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/cmd/canary/canary-config/delete_test.go
+++ b/cmd/canary/canary-config/delete_test.go
@@ -15,10 +15,13 @@
 package canary_config
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/canary"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -26,15 +29,14 @@ func TestCanaryConfigDelete_basic(t *testing.T) {
 	ts := gateServerDeleteSuccess()
 	defer ts.Close()
 
-	args := []string{"canary-config", "delete", "configId", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd()
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "delete", "configId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -44,15 +46,14 @@ func TestCanaryConfigDelete_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	args := []string{"canary-config", "delete", "configId", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd()
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "delete", "configId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -62,15 +63,14 @@ func TestCanaryConfigDelete_missingid(t *testing.T) {
 	ts := gateServerDeleteSuccess()
 	defer ts.Close()
 
-	args := []string{"canary-config", "delete", "--gate-endpoint", ts.URL} // Missing cc id.
-	currentCmd := NewDeleteCmd()
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "delete", "--gate-endpoint", ts.URL} // Missing cc id.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command errantly succeeded. %s", err)
 	}

--- a/cmd/canary/canary-config/delete_test.go
+++ b/cmd/canary/canary-config/delete_test.go
@@ -28,13 +28,13 @@ func TestCanaryConfigDelete_basic(t *testing.T) {
 
 	args := []string{"canary-config", "delete", "configId", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -46,13 +46,13 @@ func TestCanaryConfigDelete_fail(t *testing.T) {
 
 	args := []string{"canary-config", "delete", "configId", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -64,13 +64,13 @@ func TestCanaryConfigDelete_missingid(t *testing.T) {
 
 	args := []string{"canary-config", "delete", "--gate-endpoint", ts.URL} // Missing cc id.
 	currentCmd := NewDeleteCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command errantly succeeded. %s", err)
 	}

--- a/cmd/canary/canary-config/get.go
+++ b/cmd/canary/canary-config/get.go
@@ -82,6 +82,6 @@ func getCanaryConfig(cmd *cobra.Command, options GetOptions, args []string) erro
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/canary/canary-config/get.go
+++ b/cmd/canary/canary-config/get.go
@@ -17,15 +17,16 @@ package canary_config
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type GetOptions struct {
 	*canaryConfigOptions
-	id  string
+	id string
 }
 
 const (

--- a/cmd/canary/canary-config/get.go
+++ b/cmd/canary/canary-config/get.go
@@ -20,11 +20,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type GetOptions struct {
+type getOptions struct {
 	*canaryConfigOptions
 	id string
 }
@@ -34,9 +33,9 @@ const (
 	getCanaryConfigLong  = "Get the specified canary config"
 )
 
-func NewGetCmd(canaryConfigOptions canaryConfigOptions) *cobra.Command {
-	options := GetOptions{
-		canaryConfigOptions: &canaryConfigOptions,
+func NewGetCmd(canaryConfigOptions *canaryConfigOptions) *cobra.Command {
+	options := &getOptions{
+		canaryConfigOptions: canaryConfigOptions,
 	}
 	cmd := &cobra.Command{
 		Use:   "get",
@@ -52,12 +51,8 @@ func NewGetCmd(canaryConfigOptions canaryConfigOptions) *cobra.Command {
 	return cmd
 }
 
-func getCanaryConfig(cmd *cobra.Command, options GetOptions, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func getCanaryConfig(cmd *cobra.Command, options *getOptions, args []string) error {
+	var err error
 	id := options.id
 	if id == "" {
 		id, err = util.ReadArgsOrStdin(args)
@@ -69,8 +64,8 @@ func getCanaryConfig(cmd *cobra.Command, options GetOptions, args []string) erro
 		}
 	}
 
-	successPayload, resp, err := gateClient.V2CanaryConfigControllerApi.GetCanaryConfigUsingGET(
-		gateClient.Context, id, map[string]interface{}{})
+	successPayload, resp, err := options.GateClient.V2CanaryConfigControllerApi.GetCanaryConfigUsingGET(
+		options.GateClient.Context, id, map[string]interface{}{})
 
 	if err != nil {
 		return err
@@ -82,6 +77,6 @@ func getCanaryConfig(cmd *cobra.Command, options GetOptions, args []string) erro
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/canary/canary-config/get_test.go
+++ b/cmd/canary/canary-config/get_test.go
@@ -16,11 +16,14 @@ package canary_config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/canary"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,16 +31,15 @@ func TestCanaryConfigGet_basic(t *testing.T) {
 	ts := testGateCanaryConfigGetSuccess()
 	defer ts.Close()
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
-	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
+
+	args := []string{"canary", "canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -47,17 +49,15 @@ func TestCanaryConfigGet_args(t *testing.T) {
 	ts := testGateCanaryConfigGetSuccess()
 	defer ts.Close()
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	// Missing 'id' argument.
-	args := []string{"canary-config", "get", "--gate-endpoint", ts.URL}
-	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	// Missing 'id' argument.
+	args := []string{"canary", "canary-config", "get", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -67,16 +67,14 @@ func TestCanaryConfigGet_malformed(t *testing.T) {
 	ts := testGateCanaryConfigGetMalformed()
 	defer ts.Close()
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
-	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -86,16 +84,14 @@ func TestCanaryConfigGet_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
-	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -105,16 +101,15 @@ func TestPipelineGet_notfound(t *testing.T) {
 	ts := testGateCanaryConfigGetMissing()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewCanaryConfigCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
-	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
+	args := []string{"canary", "canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/canary/canary-config/get_test.go
+++ b/cmd/canary/canary-config/get_test.go
@@ -31,13 +31,13 @@ func TestCanaryConfigGet_basic(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -51,13 +51,13 @@ func TestCanaryConfigGet_args(t *testing.T) {
 	// Missing 'id' argument.
 	args := []string{"canary-config", "get", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -70,13 +70,13 @@ func TestCanaryConfigGet_malformed(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -89,13 +89,13 @@ func TestCanaryConfigGet_fail(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -106,7 +106,7 @@ func TestPipelineGet_notfound(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewCanaryConfigCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
@@ -114,7 +114,7 @@ func TestPipelineGet_notfound(t *testing.T) {
 	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/canary/canary-config/get_test.go
+++ b/cmd/canary/canary-config/get_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestCanaryConfigGet_basic(t *testing.T) {
 	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -53,7 +52,7 @@ func TestCanaryConfigGet_args(t *testing.T) {
 	args := []string{"canary-config", "get", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -72,7 +71,7 @@ func TestCanaryConfigGet_malformed(t *testing.T) {
 	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -91,7 +90,7 @@ func TestCanaryConfigGet_fail(t *testing.T) {
 	args := []string{"canary-config", "get", "--id", "3f3dbcc1", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -108,7 +107,7 @@ func TestPipelineGet_notfound(t *testing.T) {
 
 	currentCmd := NewGetCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewCanaryConfigCmd(os.Stdout)
+	pipelineTemplateCmd := NewCanaryConfigCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 

--- a/cmd/canary/canary-config/get_test.go
+++ b/cmd/canary/canary-config/get_test.go
@@ -16,12 +16,13 @@ package canary_config
 
 import (
 	"fmt"
-	"github.com/spinnaker/spin/util"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestCanaryConfigGet_basic(t *testing.T) {

--- a/cmd/canary/canary-config/list.go
+++ b/cmd/canary/canary-config/list.go
@@ -72,6 +72,6 @@ func listCanaryConfig(cmd *cobra.Command, options ListOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/canary/canary-config/list.go
+++ b/cmd/canary/canary-config/list.go
@@ -16,10 +16,11 @@ package canary_config
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type ListOptions struct {

--- a/cmd/canary/canary-config/list.go
+++ b/cmd/canary/canary-config/list.go
@@ -19,11 +19,9 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 )
 
-type ListOptions struct {
+type listOptions struct {
 	*canaryConfigOptions
 	application string
 }
@@ -33,9 +31,9 @@ const (
 	listCanaryConfigLong  = "List the canary configs"
 )
 
-func NewListCmd(canaryConfigOptions canaryConfigOptions) *cobra.Command {
-	options := ListOptions{
-		canaryConfigOptions: &canaryConfigOptions,
+func NewListCmd(canaryConfigOptions *canaryConfigOptions) *cobra.Command {
+	options := &listOptions{
+		canaryConfigOptions: canaryConfigOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -53,14 +51,9 @@ func NewListCmd(canaryConfigOptions canaryConfigOptions) *cobra.Command {
 	return cmd
 }
 
-func listCanaryConfig(cmd *cobra.Command, options ListOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
-	successPayload, resp, err := gateClient.V2CanaryConfigControllerApi.GetCanaryConfigsUsingGET(
-		gateClient.Context, map[string]interface{}{"application": options.application})
+func listCanaryConfig(cmd *cobra.Command, options *listOptions) error {
+	successPayload, resp, err := options.GateClient.V2CanaryConfigControllerApi.GetCanaryConfigsUsingGET(
+		options.GateClient.Context, map[string]interface{}{"application": options.application})
 
 	if err != nil {
 		return err
@@ -72,6 +65,6 @@ func listCanaryConfig(cmd *cobra.Command, options ListOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/canary/canary-config/list_test.go
+++ b/cmd/canary/canary-config/list_test.go
@@ -16,27 +16,14 @@ package canary_config
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/util"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
-)
 
-func getRootCmdForTest() *cobra.Command {
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
-	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
-	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
-	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
-	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
-	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
-	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
-	util.InitUI(false, false, "")
-	return rootCmd
-}
+	"github.com/spinnaker/spin/util"
+)
 
 func TestCanaryConfigList_basic(t *testing.T) {
 	ts := testGateCanaryConfigListSuccess()
@@ -45,13 +32,13 @@ func TestCanaryConfigList_basic(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -64,13 +51,13 @@ func TestCanaryConfigList_malformed(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -83,13 +70,13 @@ func TestCanaryConfigList_fail(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/canary/canary-config/list_test.go
+++ b/cmd/canary/canary-config/list_test.go
@@ -62,7 +62,7 @@ func TestCanaryConfigList_malformed(t *testing.T) {
 }
 
 func TestCanaryConfigList_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -101,9 +101,9 @@ func testGateCanaryConfigListMalformed() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// GateServerFail spins up a local http server that we will configure the GateClient
+// testGateFail spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 500 InternalServerError.
-func GateServerFail() *httptest.Server {
+func testGateFail() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}))

--- a/cmd/canary/canary-config/list_test.go
+++ b/cmd/canary/canary-config/list_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestCanaryConfigList_basic(t *testing.T) {
 	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -52,7 +51,7 @@ func TestCanaryConfigList_malformed(t *testing.T) {
 	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -71,7 +70,7 @@ func TestCanaryConfigList_fail(t *testing.T) {
 	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 

--- a/cmd/canary/canary-config/list_test.go
+++ b/cmd/canary/canary-config/list_test.go
@@ -16,11 +16,14 @@ package canary_config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/canary"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,16 +31,14 @@ func TestCanaryConfigList_basic(t *testing.T) {
 	ts := testGateCanaryConfigListSuccess()
 	defer ts.Close()
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "list", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -47,16 +48,14 @@ func TestCanaryConfigList_malformed(t *testing.T) {
 	ts := testGateCanaryConfigListMalformed()
 	defer ts.Close()
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "list", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -66,16 +65,14 @@ func TestCanaryConfigList_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "list", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "list", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/canary/canary-config/retro.go
+++ b/cmd/canary/canary-config/retro.go
@@ -208,7 +208,7 @@ func retroCanaryConfig(cmd *cobra.Command, options RetroOptions) error {
 
 	judgement := canaryResult.(map[string]interface{})["result"].(map[string]interface{})["judgeResult"].(map[string]interface{})["score"].(map[string]interface{})["classification"].(string)
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("Retrospective canary execution finished, judgement = %s", strings.ToUpper(judgement))))
+	util.UI.Info(fmt.Sprintf("Retrospective canary execution finished, judgement = %s", strings.ToUpper(judgement)))
 	if options.fullResult {
 		util.UI.JsonOutput(canaryResult)
 	}

--- a/cmd/canary/canary-config/retro.go
+++ b/cmd/canary/canary-config/retro.go
@@ -22,11 +22,10 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type RetroOptions struct {
+type retroOptions struct {
 	*canaryConfigOptions
 	output              string
 	canaryConfigFile    string
@@ -54,9 +53,9 @@ var (
 	retrySleepCycle = 6 * time.Second
 )
 
-func NewRetroCmd(canaryConfigOptions canaryConfigOptions) *cobra.Command {
-	options := RetroOptions{
-		canaryConfigOptions: &canaryConfigOptions,
+func NewRetroCmd(canaryConfigOptions *canaryConfigOptions) *cobra.Command {
+	options := &retroOptions{
+		canaryConfigOptions: canaryConfigOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "retro",
@@ -89,12 +88,7 @@ func NewRetroCmd(canaryConfigOptions canaryConfigOptions) *cobra.Command {
 	return cmd
 }
 
-func retroCanaryConfig(cmd *cobra.Command, options RetroOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func retroCanaryConfig(cmd *cobra.Command, options *retroOptions) error {
 	canaryConfigJson, err := util.ParseJsonFromFileOrStdin(options.canaryConfigFile, false)
 	if err != nil {
 		return err
@@ -156,8 +150,8 @@ func retroCanaryConfig(cmd *cobra.Command, options RetroOptions) error {
 		initiateOptionalParams["storageAccountName"] = options.storageAccount
 	}
 
-	util.UI.Info("Initiating canary execution for supplied canary config")
-	canaryExecutionResp, initiateResp, initiateErr := gateClient.V2CanaryControllerApi.InitiateCanaryWithConfigUsingPOST(gateClient.Context, adhocRequest, initiateOptionalParams)
+	options.Ui.Info("Initiating canary execution for supplied canary config")
+	canaryExecutionResp, initiateResp, initiateErr := options.GateClient.V2CanaryControllerApi.InitiateCanaryWithConfigUsingPOST(options.GateClient.Context, adhocRequest, initiateOptionalParams)
 
 	if initiateErr != nil {
 		return initiateErr
@@ -170,14 +164,14 @@ func retroCanaryConfig(cmd *cobra.Command, options RetroOptions) error {
 	}
 
 	canaryExecutionId := canaryExecutionResp.(map[string]interface{})["canaryExecutionId"].(string)
-	util.UI.Info(fmt.Sprintf("Spawned canary execution with id %s, polling for completion...", canaryExecutionId))
+	options.Ui.Info(fmt.Sprintf("Spawned canary execution with id %s, polling for completion...", canaryExecutionId))
 
 	queryOptionalParams := map[string]interface{}{}
 	if options.storageAccount != "" {
 		queryOptionalParams["storageAccountName"] = options.storageAccount
 	}
 
-	canaryResult, canaryResultResp, canaryResultErr := gateClient.V2CanaryControllerApi.GetCanaryResultUsingGET1(gateClient.Context, canaryExecutionId, queryOptionalParams)
+	canaryResult, canaryResultResp, canaryResultErr := options.GateClient.V2CanaryControllerApi.GetCanaryResultUsingGET1(options.GateClient.Context, canaryExecutionId, queryOptionalParams)
 
 	if canaryResultErr != nil {
 		return canaryResultErr
@@ -193,7 +187,7 @@ func retroCanaryConfig(cmd *cobra.Command, options RetroOptions) error {
 
 	retries := 0
 	for retries < 10 && complete == false && canaryResultErr == nil {
-		canaryResult, canaryResultResp, canaryResultErr = gateClient.V2CanaryControllerApi.GetCanaryResultUsingGET1(gateClient.Context, canaryExecutionId, queryOptionalParams)
+		canaryResult, canaryResultResp, canaryResultErr = options.GateClient.V2CanaryControllerApi.GetCanaryResultUsingGET1(options.GateClient.Context, canaryExecutionId, queryOptionalParams)
 		complete = canaryResult.(map[string]interface{})["complete"].(bool)
 		time.Sleep(retrySleepCycle)
 		retries += 1
@@ -208,14 +202,14 @@ func retroCanaryConfig(cmd *cobra.Command, options RetroOptions) error {
 
 	judgement := canaryResult.(map[string]interface{})["result"].(map[string]interface{})["judgeResult"].(map[string]interface{})["score"].(map[string]interface{})["classification"].(string)
 
-	util.UI.Info(fmt.Sprintf("Retrospective canary execution finished, judgement = %s", strings.ToUpper(judgement)))
+	options.Ui.Info(fmt.Sprintf("Retrospective canary execution finished, judgement = %s", strings.ToUpper(judgement)))
 	if options.fullResult {
-		util.UI.JsonOutput(canaryResult)
+		options.Ui.JsonOutput(canaryResult)
 	}
 	return nil
 }
 
-func validateOptions(options RetroOptions) error {
+func validateOptions(options *retroOptions) error {
 	if options.controlGroup == "" || options.controlLocation == "" {
 		return errors.New("Required control group flags not supplied")
 	}

--- a/cmd/canary/canary-config/retro.go
+++ b/cmd/canary/canary-config/retro.go
@@ -17,12 +17,13 @@ package canary_config
 import (
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd/gateclient"
+	"github.com/spinnaker/spin/util"
 )
 
 type RetroOptions struct {

--- a/cmd/canary/canary-config/retro.go
+++ b/cmd/canary/canary-config/retro.go
@@ -210,7 +210,7 @@ func retroCanaryConfig(cmd *cobra.Command, options RetroOptions) error {
 
 	util.UI.Info(util.Colorize().Color(fmt.Sprintf("Retrospective canary execution finished, judgement = %s", strings.ToUpper(judgement))))
 	if options.fullResult {
-		util.UI.JsonOutput(canaryResult, util.UI.OutputFormat)
+		util.UI.JsonOutput(canaryResult)
 	}
 	return nil
 }

--- a/cmd/canary/canary-config/retro_test.go
+++ b/cmd/canary/canary-config/retro_test.go
@@ -15,12 +15,13 @@
 package canary_config
 
 import (
-	"github.com/spinnaker/spin/util"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestCanaryConfigRetro_file(t *testing.T) {

--- a/cmd/canary/canary-config/retro_test.go
+++ b/cmd/canary/canary-config/retro_test.go
@@ -15,12 +15,15 @@
 package canary_config
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/canary"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -33,8 +36,14 @@ func TestCanaryConfigRetro_file(t *testing.T) {
 		t.Fatal("Could not create temp canary config file.")
 	}
 	defer os.Remove(tempFile.Name())
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "retro",
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
+
+	args := []string{
+		"canary", "canary-config", "retro",
 		"--file", tempFile.Name(),
 		"--control-group", "control-v000",
 		"--control-location", "us-central1",
@@ -42,16 +51,10 @@ func TestCanaryConfigRetro_file(t *testing.T) {
 		"--experiment-location", "us-central1",
 		"--start", "2019-09-17T17:16:02.600Z",
 		"--end", "2019-09-17T18:16:02.600Z",
-		"--gate-endpoint", ts.URL}
-
-	currentCmd := NewRetroCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
-
+		"--gate-endpoint", ts.URL,
+	}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -73,23 +76,23 @@ func TestCanaryConfigRetro_stdin(t *testing.T) {
 	defer func() { os.Stdin = oldStdin }()
 	os.Stdin = tempFile
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "retro",
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
+
+	args := []string{
+		"canary", "canary-config", "retro",
 		"--control-group", "control-v000",
 		"--control-location", "us-central1",
 		"--experiment-group", "experiment-v000",
 		"--experiment-location", "us-central1",
 		"--start", "2019-09-17T17:16:02.600Z",
 		"--end", "2019-09-17T18:16:02.600Z",
-		"--gate-endpoint", ts.URL}
-	currentCmd := NewRetroCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
-
+		"--gate-endpoint", ts.URL,
+	}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -105,8 +108,13 @@ func TestCanaryConfigRetro_fail(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "retro",
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
+
+	args := []string{
+		"canary", "canary-config", "retro",
 		"--file", tempFile.Name(),
 		"--control-group", "control-v000",
 		"--control-location", "us-central1",
@@ -114,15 +122,10 @@ func TestCanaryConfigRetro_fail(t *testing.T) {
 		"--experiment-location", "us-central1",
 		"--start", "2019-09-17T17:16:02.600Z",
 		"--end", "2019-09-17T18:16:02.600Z",
-		"--gate-endpoint", ts.URL}
-	currentCmd := NewRetroCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
-
+		"--gate-endpoint", ts.URL,
+	}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -140,8 +143,13 @@ func TestCanaryConfigRetro_timeout(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "retro",
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
+
+	args := []string{
+		"canary", "canary-config", "retro",
 		"--file", tempFile.Name(),
 		"--control-group", "control-v000",
 		"--control-location", "us-central1",
@@ -149,15 +157,10 @@ func TestCanaryConfigRetro_timeout(t *testing.T) {
 		"--experiment-location", "us-central1",
 		"--start", "2019-09-17T17:16:02.600Z",
 		"--end", "2019-09-17T18:16:02.600Z",
-		"--gate-endpoint", ts.URL}
-	currentCmd := NewRetroCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
-
+		"--gate-endpoint", ts.URL,
+	}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/canary/canary-config/retro_test.go
+++ b/cmd/canary/canary-config/retro_test.go
@@ -46,7 +46,7 @@ func TestCanaryConfigRetro_file(t *testing.T) {
 
 	currentCmd := NewRetroCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -84,7 +84,7 @@ func TestCanaryConfigRetro_stdin(t *testing.T) {
 		"--gate-endpoint", ts.URL}
 	currentCmd := NewRetroCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -117,7 +117,7 @@ func TestCanaryConfigRetro_fail(t *testing.T) {
 		"--gate-endpoint", ts.URL}
 	currentCmd := NewRetroCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -152,7 +152,7 @@ func TestCanaryConfigRetro_timeout(t *testing.T) {
 		"--gate-endpoint", ts.URL}
 	currentCmd := NewRetroCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 

--- a/cmd/canary/canary-config/retro_test.go
+++ b/cmd/canary/canary-config/retro_test.go
@@ -99,7 +99,7 @@ func TestCanaryConfigRetro_stdin(t *testing.T) {
 }
 
 func TestCanaryConfigRetro_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	tempFile := tempCanaryConfigFile(testCanaryConfigJsonStr)

--- a/cmd/canary/canary-config/retro_test.go
+++ b/cmd/canary/canary-config/retro_test.go
@@ -44,13 +44,13 @@ func TestCanaryConfigRetro_file(t *testing.T) {
 		"--gate-endpoint", ts.URL}
 
 	currentCmd := NewRetroCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -82,13 +82,13 @@ func TestCanaryConfigRetro_stdin(t *testing.T) {
 		"--end", "2019-09-17T18:16:02.600Z",
 		"--gate-endpoint", ts.URL}
 	currentCmd := NewRetroCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -115,13 +115,13 @@ func TestCanaryConfigRetro_fail(t *testing.T) {
 		"--end", "2019-09-17T18:16:02.600Z",
 		"--gate-endpoint", ts.URL}
 	currentCmd := NewRetroCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -150,13 +150,13 @@ func TestCanaryConfigRetro_timeout(t *testing.T) {
 		"--end", "2019-09-17T18:16:02.600Z",
 		"--gate-endpoint", ts.URL}
 	currentCmd := NewRetroCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/canary/canary-config/save.go
+++ b/cmd/canary/canary-config/save.go
@@ -102,6 +102,6 @@ func saveCanaryConfig(cmd *cobra.Command, options SaveOptions) error {
 			templateJson, saveResp.StatusCode)
 	}
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Canary config save succeeded")))
+	util.UI.Success("Canary config save succeeded")
 	return nil
 }

--- a/cmd/canary/canary-config/save.go
+++ b/cmd/canary/canary-config/save.go
@@ -16,10 +16,11 @@ package canary_config
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type SaveOptions struct {

--- a/cmd/canary/canary-config/save.go
+++ b/cmd/canary/canary-config/save.go
@@ -19,11 +19,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type SaveOptions struct {
+type saveOptions struct {
 	*canaryConfigOptions
 	output       string
 	templateFile string
@@ -34,9 +33,9 @@ const (
 	saveTemplateLong  = "Save the provided canary config"
 )
 
-func NewSaveCmd(canaryConfigOptions canaryConfigOptions) *cobra.Command {
-	options := SaveOptions{
-		canaryConfigOptions: &canaryConfigOptions,
+func NewSaveCmd(canaryConfigOptions *canaryConfigOptions) *cobra.Command {
+	options := &saveOptions{
+		canaryConfigOptions: canaryConfigOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "save",
@@ -54,35 +53,30 @@ func NewSaveCmd(canaryConfigOptions canaryConfigOptions) *cobra.Command {
 	return cmd
 }
 
-func saveCanaryConfig(cmd *cobra.Command, options SaveOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func saveCanaryConfig(cmd *cobra.Command, options *saveOptions) error {
 	templateJson, err := util.ParseJsonFromFileOrStdin(options.templateFile, false)
 	if err != nil {
 		return err
 	}
 
 	if _, exists := templateJson["id"]; !exists {
-		util.UI.Error("Required canary config key 'id' missing...\n")
+		options.Ui.Error("Required canary config key 'id' missing...\n")
 		return fmt.Errorf("Submitted canary config is invalid: %s\n", templateJson)
 	}
 
 	templateId := templateJson["id"].(string)
 
-	_, resp, queryErr := gateClient.V2CanaryConfigControllerApi.GetCanaryConfigUsingGET(
-		gateClient.Context, templateId, map[string]interface{}{})
+	_, resp, queryErr := options.GateClient.V2CanaryConfigControllerApi.GetCanaryConfigUsingGET(
+		options.GateClient.Context, templateId, map[string]interface{}{})
 
 	var saveResp *http.Response
 	var saveErr error
 	if resp.StatusCode == http.StatusOK {
-		_, saveResp, saveErr = gateClient.V2CanaryConfigControllerApi.UpdateCanaryConfigUsingPUT(
-			gateClient.Context, templateJson, templateId, map[string]interface{}{})
+		_, saveResp, saveErr = options.GateClient.V2CanaryConfigControllerApi.UpdateCanaryConfigUsingPUT(
+			options.GateClient.Context, templateJson, templateId, map[string]interface{}{})
 	} else if resp.StatusCode == http.StatusNotFound {
-		_, saveResp, saveErr = gateClient.V2CanaryConfigControllerApi.CreateCanaryConfigUsingPOST(
-			gateClient.Context, templateJson, map[string]interface{}{})
+		_, saveResp, saveErr = options.GateClient.V2CanaryConfigControllerApi.CreateCanaryConfigUsingPOST(
+			options.GateClient.Context, templateJson, map[string]interface{}{})
 	} else {
 		if queryErr != nil {
 			return queryErr
@@ -102,6 +96,6 @@ func saveCanaryConfig(cmd *cobra.Command, options SaveOptions) error {
 			templateJson, saveResp.StatusCode)
 	}
 
-	util.UI.Success("Canary config save succeeded")
+	options.Ui.Success("Canary config save succeeded")
 	return nil
 }

--- a/cmd/canary/canary-config/save_test.go
+++ b/cmd/canary/canary-config/save_test.go
@@ -16,12 +16,13 @@ package canary_config
 
 import (
 	"fmt"
-	"github.com/spinnaker/spin/util"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestCanaryConfigSave_create(t *testing.T) {
@@ -192,7 +193,7 @@ func gateServerUpdateSuccess() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	// Return that there are no existing CCs on GET and a successful id on PUT.
 	mux.Handle("/v2/canaryConfig/exampleCanaryConfigId", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if (r.Method == http.MethodPut) {
+		if r.Method == http.MethodPut {
 			w.Write([]byte(responseJson))
 		} else {
 			w.WriteHeader(http.StatusOK)

--- a/cmd/canary/canary-config/save_test.go
+++ b/cmd/canary/canary-config/save_test.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/canary"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -34,17 +36,15 @@ func TestCanaryConfigSave_create(t *testing.T) {
 		t.Fatal("Could not create temp canary config file.")
 	}
 	defer os.Remove(tempFile.Name())
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
-	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -59,17 +59,15 @@ func TestCanaryConfigSave_update(t *testing.T) {
 		t.Fatal("Could not create temp canary config file.")
 	}
 	defer os.Remove(tempFile.Name())
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
-	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -91,16 +89,14 @@ func TestCanaryConfigSave_stdin(t *testing.T) {
 	defer func() { os.Stdin = oldStdin }()
 	os.Stdin = tempFile
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "save", "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "save", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -116,16 +112,14 @@ func TestCanaryConfigSave_fail(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -135,17 +129,15 @@ func TestCanaryConfigSave_flags(t *testing.T) {
 	ts := gateServerUpdateSuccess()
 	defer ts.Close()
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	// Missing canary config spec file and stdin.
-	args := []string{"canary-config", "save", "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	// Missing canary config spec file and stdin.
+	args := []string{"canary", "canary-config", "save", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -161,16 +153,14 @@ func TestCanaryConfigSave_missingid(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
-	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd()
-	canaryConfigCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(canaryConfigCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
 
+	args := []string{"canary", "canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/canary/canary-config/save_test.go
+++ b/cmd/canary/canary-config/save_test.go
@@ -39,7 +39,7 @@ func TestCanaryConfigSave_create(t *testing.T) {
 
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -64,7 +64,7 @@ func TestCanaryConfigSave_update(t *testing.T) {
 
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -95,7 +95,7 @@ func TestCanaryConfigSave_stdin(t *testing.T) {
 	args := []string{"canary-config", "save", "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -120,7 +120,7 @@ func TestCanaryConfigSave_fail(t *testing.T) {
 	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -140,7 +140,7 @@ func TestCanaryConfigSave_flags(t *testing.T) {
 	args := []string{"canary-config", "save", "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
@@ -165,7 +165,7 @@ func TestCanaryConfigSave_missingid(t *testing.T) {
 	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
+	canaryConfigCmd := NewCanaryConfigCmd()
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 

--- a/cmd/canary/canary-config/save_test.go
+++ b/cmd/canary/canary-config/save_test.go
@@ -15,11 +15,14 @@
 package canary_config
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spinnaker/spin/cmd"
@@ -27,8 +30,9 @@ import (
 	"github.com/spinnaker/spin/util"
 )
 
-func TestCanaryConfigSave_create(t *testing.T) {
-	ts := gateServerCreateSuccess()
+func TestCanaryConfigSave_createjson(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateCanaryConfigSaveSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempCanaryConfigFile(testCanaryConfigJsonStr)
@@ -48,10 +52,43 @@ func TestCanaryConfigSave_create(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testCanaryConfigJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
+}
+
+func TestCanaryConfigSave_createyaml(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateCanaryConfigSaveSuccess(saveBuffer)
+	defer ts.Close()
+
+	tempFile := tempCanaryConfigFile(testCanaryConfigYamlStr)
+	if tempFile == nil {
+		t.Fatal("Could not create temp canary config file.")
+	}
+	defer os.Remove(tempFile.Name())
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	canaryCmd, canaryOpts := canary.NewCanaryCmd(rootOpts)
+	canaryCmd.AddCommand(NewCanaryConfigCmd(canaryOpts))
+	rootCmd.AddCommand(canaryCmd)
+
+	args := []string{"canary", "canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(testCanaryConfigJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestCanaryConfigSave_update(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateCanaryConfigUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempCanaryConfigFile(testCanaryConfigJsonStr)
@@ -71,10 +108,15 @@ func TestCanaryConfigSave_update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testCanaryConfigJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestCanaryConfigSave_stdin(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateCanaryConfigUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempCanaryConfigFile(testCanaryConfigJsonStr)
@@ -100,10 +142,14 @@ func TestCanaryConfigSave_stdin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testCanaryConfigJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestCanaryConfigSave_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	tempFile := tempCanaryConfigFile(testCanaryConfigJsonStr)
@@ -126,7 +172,8 @@ func TestCanaryConfigSave_fail(t *testing.T) {
 }
 
 func TestCanaryConfigSave_flags(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateCanaryConfigUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -141,10 +188,17 @@ func TestCanaryConfigSave_flags(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := ""
+	recieved := strings.TrimSpace(saveBuffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected save request body:\n%s", recieved)
+	}
 }
 
 func TestCanaryConfigSave_missingid(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateCanaryConfigUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempCanaryConfigFile(missingIdJsonStr)
@@ -164,6 +218,12 @@ func TestCanaryConfigSave_missingid(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := ""
+	recieved := strings.TrimSpace(saveBuffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected save request body:\n%s", recieved)
+	}
 }
 
 func tempCanaryConfigFile(canaryConfigContent string) *os.File {
@@ -176,14 +236,23 @@ func tempCanaryConfigFile(canaryConfigContent string) *os.File {
 	return tempFile
 }
 
-// gateServerUpdateSuccess spins up a local http server that we will configure the GateClient
+// testGateCanaryConfigUpdateSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with OK to indicate a canary config exists,
 // and Accepts POST calls.
-func gateServerUpdateSuccess() *httptest.Server {
+// Writes request body to buffer for testing.
+func testGateCanaryConfigUpdateSuccess(buffer io.Writer) *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	// Return that there are no existing CCs on GET and a successful id on PUT.
 	mux.Handle("/v2/canaryConfig/exampleCanaryConfigId", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut {
+			defer r.Body.Close()
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "Failed to ready body", http.StatusInternalServerError)
+				return
+			}
+			buffer.Write([]byte(body))
+
 			w.Write([]byte(responseJson))
 		} else {
 			w.WriteHeader(http.StatusOK)
@@ -192,12 +261,21 @@ func gateServerUpdateSuccess() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// gateServerCreateSuccess spins up a local http server that we will configure the GateClient
+// testGateCanaryConfigSaveSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with 404 NotFound to indicate a canary config doesn't exist,
 // and Accepts POST calls.
-func gateServerCreateSuccess() *httptest.Server {
+// Writes request body to buffer for testing.
+func testGateCanaryConfigSaveSuccess(buffer io.Writer) *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/v2/canaryConfig", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "Failed to ready body", http.StatusInternalServerError)
+			return
+		}
+		buffer.Write([]byte(body))
+
 		w.Write([]byte(responseJson))
 	}))
 	// Return that we found no CC to signal a create.
@@ -267,53 +345,91 @@ const missingIdJsonStr = `
 
 const testCanaryConfigJsonStr = `
 {
-   "applications": [
-      "canaryconfigs"
-   ],
-   "classifier": {
-      "groupWeights": {
-         "Errors": 100
-      },
-      "scoreThresholds": {
-         "marginal": 75,
-         "pass": 95
-      }
+ "applications": [
+  "canaryconfigs"
+ ],
+ "classifier": {
+  "groupWeights": {
+   "Errors": 100
+  },
+  "scoreThresholds": {
+   "marginal": 75,
+   "pass": 95
+  }
+ },
+ "configVersion": "1",
+ "description": "Base canary config",
+ "id": "exampleCanaryConfigId",
+ "judge": {
+  "judgeConfigurations": {},
+  "name": "NetflixACAJudge-v1.0"
+ },
+ "metrics": [
+  {
+   "analysisConfigurations": {
+    "canary": {
+     "direction": "increase",
+     "nanStrategy": "replace"
+    }
    },
-   "configVersion": "1",
-   "description": "Base canary config",
-   "id": "exampleCanaryConfigId",
-   "judge": {
-      "judgeConfigurations": { },
-      "name": "NetflixACAJudge-v1.0"
-   },
-   "metrics": [
-      {
-         "analysisConfigurations": {
-            "canary": {
-               "direction": "increase",
-               "nanStrategy": "replace"
-            }
-         },
-         "groups": [
-            "Errors"
-         ],
-         "name": "RequestFailureRate",
-         "query": {
-            "crossSeriesReducer": "REDUCE_SUM",
-            "customFilterTemplate": "ServiceGroupFilter",
-            "groupByFields": [ ],
-            "metricType": "custom.googleapis.com/server/failure_rate",
-            "perSeriesAligner": "ALIGN_MEAN",
-            "resourceType": "aws_ec2_instance",
-            "serviceType": "stackdriver",
-            "type": "stackdriver"
-         },
-         "scopeName": "default"
-      }
+   "groups": [
+    "Errors"
    ],
-   "name": "exampleCanary",
-   "templates": {
-      "ServiceGroupFilter": "metric.label.group_name = \"${scope}\""
-   }
+   "name": "RequestFailureRate",
+   "query": {
+    "crossSeriesReducer": "REDUCE_SUM",
+    "customFilterTemplate": "ServiceGroupFilter",
+    "groupByFields": [],
+    "metricType": "custom.googleapis.com/server/failure_rate",
+    "perSeriesAligner": "ALIGN_MEAN",
+    "resourceType": "aws_ec2_instance",
+    "serviceType": "stackdriver",
+    "type": "stackdriver"
+   },
+   "scopeName": "default"
+  }
+ ],
+ "name": "exampleCanary",
+ "templates": {
+  "ServiceGroupFilter": "metric.label.group_name = \"${scope}\""
+ }
 }
+`
+
+const testCanaryConfigYamlStr = `
+applications:
+- canaryconfigs
+classifier:
+  groupWeights:
+    Errors: 100
+  scoreThresholds:
+    marginal: 75
+    pass: 95
+configVersion: '1'
+description: Base canary config
+id: exampleCanaryConfigId
+judge:
+  judgeConfigurations: {}
+  name: NetflixACAJudge-v1.0
+metrics:
+- analysisConfigurations:
+    canary:
+      direction: increase
+      nanStrategy: replace
+  groups:
+  - Errors
+  name: RequestFailureRate
+  query:
+    crossSeriesReducer: REDUCE_SUM
+    customFilterTemplate: ServiceGroupFilter
+    groupByFields: []
+    metricType: custom.googleapis.com/server/failure_rate
+    perSeriesAligner: ALIGN_MEAN
+    resourceType: aws_ec2_instance
+    serviceType: stackdriver
+    type: stackdriver
+  scopeName: default
+name: exampleCanary
+templates:
+  ServiceGroupFilter: metric.label.group_name = "${scope}"
 `

--- a/cmd/canary/canary-config/save_test.go
+++ b/cmd/canary/canary-config/save_test.go
@@ -37,13 +37,13 @@ func TestCanaryConfigSave_create(t *testing.T) {
 	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -62,13 +62,13 @@ func TestCanaryConfigSave_update(t *testing.T) {
 	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -93,13 +93,13 @@ func TestCanaryConfigSave_stdin(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "save", "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -118,13 +118,13 @@ func TestCanaryConfigSave_fail(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -138,13 +138,13 @@ func TestCanaryConfigSave_flags(t *testing.T) {
 	// Missing canary config spec file and stdin.
 	args := []string{"canary-config", "save", "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -163,13 +163,13 @@ func TestCanaryConfigSave_missingid(t *testing.T) {
 	// Exclude 'canary' since we are testing only the 'canary-config' subcommand.
 	args := []string{"canary-config", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(canaryConfigOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	canaryConfigCmd := NewCanaryConfigCmd(os.Stdout)
 	canaryConfigCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(canaryConfigCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/canary/canary.go
+++ b/cmd/canary/canary.go
@@ -1,9 +1,10 @@
 package canary
 
 import (
+	"io"
+
 	"github.com/spf13/cobra"
 	canary_config "github.com/spinnaker/spin/cmd/canary/canary-config"
-	"io"
 )
 
 type canaryOptions struct{}

--- a/cmd/canary/canary.go
+++ b/cmd/canary/canary.go
@@ -1,8 +1,6 @@
 package canary
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 	canary_config "github.com/spinnaker/spin/cmd/canary/canary-config"
 )
@@ -15,7 +13,7 @@ const (
 	canaryExample = ""
 )
 
-func NewCanaryCmd(out io.Writer) *cobra.Command {
+func NewCanaryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "canary",
 		Aliases: []string{},
@@ -25,6 +23,6 @@ func NewCanaryCmd(out io.Writer) *cobra.Command {
 	}
 
 	// create subcommands
-	cmd.AddCommand(canary_config.NewCanaryConfigCmd(out))
+	cmd.AddCommand(canary_config.NewCanaryConfigCmd())
 	return cmd
 }

--- a/cmd/canary/canary.go
+++ b/cmd/canary/canary.go
@@ -2,10 +2,12 @@ package canary
 
 import (
 	"github.com/spf13/cobra"
-	canary_config "github.com/spinnaker/spin/cmd/canary/canary-config"
+	"github.com/spinnaker/spin/cmd"
 )
 
-type canaryOptions struct{}
+type CanaryOptions struct {
+	*cmd.RootOptions
+}
 
 const (
 	canaryShort   = ""
@@ -13,7 +15,10 @@ const (
 	canaryExample = ""
 )
 
-func NewCanaryCmd() *cobra.Command {
+func NewCanaryCmd(rootOptions *cmd.RootOptions) (*cobra.Command, *CanaryOptions) {
+	options := &CanaryOptions{
+		RootOptions: rootOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "canary",
 		Aliases: []string{},
@@ -21,8 +26,5 @@ func NewCanaryCmd() *cobra.Command {
 		Long:    canaryLong,
 		Example: canaryExample,
 	}
-
-	// create subcommands
-	cmd.AddCommand(canary_config.NewCanaryConfigCmd())
-	return cmd
+	return cmd, options
 }

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -41,7 +41,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"crypto/sha256"
 	"encoding/base64"

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -34,11 +34,11 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/spinnaker/spin/cmd/output"
 	"github.com/spinnaker/spin/config"
 	iap "github.com/spinnaker/spin/config/auth/iap"
 	"github.com/spinnaker/spin/util"
 	"github.com/spinnaker/spin/version"
-	"github.com/spinnaker/spin/cmd/output"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/pflag"
@@ -242,11 +242,11 @@ func configureOutput(flags *pflag.FlagSet) error {
 	if err != nil {
 		return err
 	}
-	outFmt, err := output.ParseOutputFormat(outputFormat)
+	outputFormater, err := output.ParseOutputFormat(outputFormat)
 	if err != nil {
 		return err
 	}
-	util.InitUI(quiet, nocolor, outFmt)
+	util.InitUI(quiet, nocolor, outputFormater)
 	return nil
 }
 

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -34,14 +34,12 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/spinnaker/spin/cmd/output"
 	"github.com/spinnaker/spin/config"
 	iap "github.com/spinnaker/spin/config/auth/iap"
 	"github.com/spinnaker/spin/util"
 	"github.com/spinnaker/spin/version"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/pflag"
 	"sigs.k8s.io/yaml"
 
 	"crypto/sha256"
@@ -85,6 +83,8 @@ type GatewayClient struct {
 
 	// Raw Http Client to do OAuth2 login.
 	httpClient *http.Client
+
+	ui util.Ui
 }
 
 func (m *GatewayClient) GateEndpoint() string {
@@ -98,18 +98,14 @@ func (m *GatewayClient) GateEndpoint() string {
 }
 
 // Create new spinnaker gateway client with flag
-func NewGateClient(flags *pflag.FlagSet) (*GatewayClient, error) {
-	err := configureOutput(flags)
-	if err != nil {
-		return nil, err
+func NewGateClient(ui util.Ui, gateEndpoint, defaultHeaders, configLocation string, ignoreCertErrors bool) (*GatewayClient, error) {
+	gateClient := &GatewayClient{
+		gateEndpoint:     gateEndpoint,
+		ignoreCertErrors: ignoreCertErrors,
+		ui:               ui,
 	}
 
-	gateClient, err := createClient(flags)
-	if err != nil {
-		return nil, err
-	}
-
-	err = userConfig(flags, gateClient)
+	err := userConfig(gateClient, configLocation)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +113,7 @@ func NewGateClient(flags *pflag.FlagSet) (*GatewayClient, error) {
 	// Api client initialization.
 	httpClient, err := gateClient.initializeClient()
 	if err != nil {
-		util.UI.Error("Could not initialize http client, failing.")
+		ui.Error("Could not initialize http client, failing.")
 		return nil, err
 	}
 
@@ -125,27 +121,22 @@ func NewGateClient(flags *pflag.FlagSet) (*GatewayClient, error) {
 
 	err = gateClient.authenticateOAuth2()
 	if err != nil {
-		util.UI.Error("OAuth2 Authentication failed.")
+		ui.Error("OAuth2 Authentication failed.")
 		return nil, err
 	}
 
 	err = gateClient.authenticateGoogleServiceAccount()
 	if err != nil {
-		util.UI.Error(fmt.Sprintf("Google service account authentication failed: %v", err))
+		ui.Error(fmt.Sprintf("Google service account authentication failed: %v", err))
 		return nil, err
 	}
 
 	if err = gateClient.authenticateLdap(); err != nil {
-		util.UI.Error("LDAP Authentication Failed")
+		ui.Error("LDAP Authentication Failed")
 		return nil, err
 	}
 
 	m := make(map[string]string)
-
-	defaultHeaders, err := flags.GetString("default-headers")
-	if err != nil {
-		return nil, err
-	}
 
 	if defaultHeaders != "" {
 		headers := strings.Split(defaultHeaders, ",")
@@ -169,20 +160,16 @@ func NewGateClient(flags *pflag.FlagSet) (*GatewayClient, error) {
 	// TODO: Verify version compatibility between Spin CLI and Gate.
 	_, _, err = gateClient.VersionControllerApi.GetVersionUsingGET(gateClient.Context)
 	if err != nil {
-		util.UI.Error("Could not reach Gate, please ensure it is running. Failing.")
+		ui.Error("Could not reach Gate, please ensure it is running. Failing.")
 		return nil, err
 	}
 
 	return gateClient, nil
 }
 
-func userConfig(flags *pflag.FlagSet, gateClient *GatewayClient) error {
-	configLocationFlag, err := flags.GetString("config")
-	if err != nil {
-		return err
-	}
-	if configLocationFlag != "" {
-		gateClient.configLocation = configLocationFlag
+func userConfig(gateClient *GatewayClient, configLocation string) error {
+	if configLocation != "" {
+		gateClient.configLocation = configLocation
 	} else {
 		userHome := ""
 		usr, err := user.Current()
@@ -192,7 +179,7 @@ func userConfig(flags *pflag.FlagSet, gateClient *GatewayClient) error {
 			if userHome != "" {
 				err = nil
 			} else {
-				util.UI.Error("Could not read current user from environment, failing.")
+				gateClient.ui.Error("Could not read current user from environment, failing.")
 				return err
 			}
 		} else {
@@ -205,48 +192,12 @@ func userConfig(flags *pflag.FlagSet, gateClient *GatewayClient) error {
 	if yamlFile != nil {
 		err = yaml.UnmarshalStrict([]byte(os.ExpandEnv(string(yamlFile))), &gateClient.Config)
 		if err != nil {
-			util.UI.Error(fmt.Sprintf("Could not deserialize config file with contents: %s, failing.", yamlFile))
+			gateClient.ui.Error(fmt.Sprintf("Could not deserialize config file with contents: %s, failing.", yamlFile))
 			return err
 		}
 	} else {
 		gateClient.Config = config.Config{}
 	}
-	return nil
-}
-
-func createClient(flags *pflag.FlagSet) (*GatewayClient, error) {
-	gateEndpoint, err := flags.GetString("gate-endpoint")
-	if err != nil {
-		return nil, err
-	}
-	ignoreCertErrors, err := flags.GetBool("insecure")
-	if err != nil {
-		return nil, err
-	}
-	return &GatewayClient{
-		gateEndpoint:     gateEndpoint,
-		ignoreCertErrors: ignoreCertErrors,
-	}, nil
-}
-
-func configureOutput(flags *pflag.FlagSet) error {
-	quiet, err := flags.GetBool("quiet")
-	if err != nil {
-		return err
-	}
-	nocolor, err := flags.GetBool("no-color")
-	if err != nil {
-		return err
-	}
-	outputFormat, err := flags.GetString("output")
-	if err != nil {
-		return err
-	}
-	outputFormater, err := output.ParseOutputFormat(outputFormat)
-	if err != nil {
-		return err
-	}
-	util.InitUI(quiet, nocolor, outputFormater)
 	return nil
 }
 
@@ -365,7 +316,7 @@ func (m *GatewayClient) authenticateOAuth2() error {
 			tokenSource := config.TokenSource(context.Background(), token)
 			newToken, err = tokenSource.Token()
 			if err != nil {
-				util.UI.Error(fmt.Sprintf("Could not refresh token from source: %v", tokenSource))
+				m.ui.Error(fmt.Sprintf("Could not refresh token from source: %v", tokenSource))
 				return err
 			}
 		} else {
@@ -377,7 +328,7 @@ func (m *GatewayClient) authenticateOAuth2() error {
 			go http.ListenAndServe(":8085", nil)
 			// Note: leaving server connection open for scope of request, will be reaped on exit.
 
-			verifier, verifierCode, err := generateCodeVerifier()
+			verifier, verifierCode, err := m.generateCodeVerifier()
 			if err != nil {
 				return err
 			}
@@ -387,8 +338,8 @@ func (m *GatewayClient) authenticateOAuth2() error {
 			challengeMethod := oauth2.SetAuthURLParam("code_challenge_method", "S256")
 
 			authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline, oauth2.ApprovalForce, challengeMethod, codeChallenge)
-			util.UI.Output(fmt.Sprintf("Navigate to %s and authenticate", authURL))
-			code := prompt("Paste authorization code:")
+			m.ui.Output(fmt.Sprintf("Navigate to %s and authenticate", authURL))
+			code := m.prompt("Paste authorization code:")
 
 			newToken, err = config.Exchange(context.Background(), code, codeVerifier)
 			if err != nil {
@@ -396,7 +347,7 @@ func (m *GatewayClient) authenticateOAuth2() error {
 			}
 		}
 
-		util.UI.Info("Caching oauth2 token.")
+		m.ui.Info("Caching oauth2 token.")
 		OAuth2.CachedToken = newToken
 		_ = m.writeYAMLConfig()
 
@@ -476,11 +427,11 @@ func (m *GatewayClient) authenticateLdap() error {
 	auth := m.Config.Auth
 	if auth != nil && auth.Enabled && auth.Ldap != nil {
 		if auth.Ldap.Username == "" {
-			auth.Ldap.Username = prompt("Username:")
+			auth.Ldap.Username = m.prompt("Username:")
 		}
 
 		if auth.Ldap.Password == "" {
-			auth.Ldap.Password = securePrompt("Password:")
+			auth.Ldap.Password = m.securePrompt("Password:")
 		}
 
 		if !auth.Ldap.IsValid() {
@@ -516,7 +467,7 @@ func (m *GatewayClient) writeYAMLConfig() error {
 	// The default permissions should only be used if the file no longer exists.
 	err := writeYAML(&m.Config, m.configLocation, defaultConfigFileMode)
 	if err != nil {
-		util.UI.Warn(fmt.Sprintf("Error caching oauth2 token: %v", err))
+		m.ui.Warn(fmt.Sprintf("Error caching oauth2 token: %v", err))
 	}
 	return err
 }
@@ -543,10 +494,10 @@ func writeYAML(v interface{}, dest string, defaultMode os.FileMode) error {
 // generateCodeVerifier generates an OAuth2 code verifier
 // in accordance to https://www.oauth.com/oauth2-servers/pkce/authorization-request and
 // https://tools.ietf.org/html/rfc7636#section-4.1.
-func generateCodeVerifier() (verifier string, code string, err error) {
+func (m *GatewayClient) generateCodeVerifier() (verifier string, code string, err error) {
 	randomBytes := make([]byte, 64)
 	if _, err := rand.Read(randomBytes); err != nil {
-		util.UI.Error("Could not generate random string for code_verifier")
+		m.ui.Error("Could not generate random string for code_verifier")
 		return "", "", err
 	}
 	verifier = base64.RawURLEncoding.EncodeToString(randomBytes)
@@ -555,15 +506,15 @@ func generateCodeVerifier() (verifier string, code string, err error) {
 	return verifier, code, nil
 }
 
-func prompt(inputMsg string) string {
+func (m *GatewayClient) prompt(inputMsg string) string {
 	reader := bufio.NewReader(os.Stdin)
-	util.UI.Output(inputMsg)
+	m.ui.Output(inputMsg)
 	text, _ := reader.ReadString('\n')
 	return strings.TrimSpace(text)
 }
 
-func securePrompt(inputMsg string) string {
-	util.UI.Output(inputMsg)
+func (m *GatewayClient) securePrompt(inputMsg string) string {
+	m.ui.Output(inputMsg)
 	byteSecret, _ := terminal.ReadPassword(int(syscall.Stdin))
 	secret := string(byteSecret)
 	return strings.TrimSpace(secret)

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -32,7 +32,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
-  "syscall"
+	"syscall"
 
 	"github.com/spinnaker/spin/config"
 	iap "github.com/spinnaker/spin/config/auth/iap"
@@ -470,14 +470,13 @@ func (m *GatewayClient) login(accessToken string) error {
 func (m *GatewayClient) authenticateLdap() error {
 	auth := m.Config.Auth
 	if auth != nil && auth.Enabled && auth.Ldap != nil {
-    if auth.Ldap.Username == "" {
-      auth.Ldap.Username = prompt("Username:")
-    }
+		if auth.Ldap.Username == "" {
+			auth.Ldap.Username = prompt("Username:")
+		}
 
-    if auth.Ldap.Password == "" {
-      auth.Ldap.Password = securePrompt("Password:")
-    }
-
+		if auth.Ldap.Password == "" {
+			auth.Ldap.Password = securePrompt("Password:")
+		}
 
 		if !auth.Ldap.IsValid() {
 			return errors.New("Incorrect LDAP auth configuration. Must include username and password.")
@@ -560,7 +559,7 @@ func prompt(inputMsg string) string {
 
 func securePrompt(inputMsg string) string {
 	util.UI.Output(inputMsg)
-  byteSecret, _ := terminal.ReadPassword(int(syscall.Stdin))
-  secret := string(byteSecret)
+	byteSecret, _ := terminal.ReadPassword(int(syscall.Stdin))
+	secret := string(byteSecret)
 	return strings.TrimSpace(secret)
 }

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -38,6 +38,7 @@ import (
 	iap "github.com/spinnaker/spin/config/auth/iap"
 	"github.com/spinnaker/spin/util"
 	"github.com/spinnaker/spin/version"
+	"github.com/spinnaker/spin/cmd/output"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/pflag"
@@ -241,7 +242,11 @@ func configureOutput(flags *pflag.FlagSet) error {
 	if err != nil {
 		return err
 	}
-	util.InitUI(quiet, nocolor, outputFormat)
+	outFmt, err := output.ParseOutputFormat(outputFormat)
+	if err != nil {
+		return err
+	}
+	util.InitUI(quiet, nocolor, outFmt)
 	return nil
 }
 

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -34,9 +34,9 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/spinnaker/spin/cmd/output"
 	"github.com/spinnaker/spin/config"
 	iap "github.com/spinnaker/spin/config/auth/iap"
-	"github.com/spinnaker/spin/util"
 	"github.com/spinnaker/spin/version"
 
 	"github.com/mitchellh/go-homedir"
@@ -84,7 +84,7 @@ type GatewayClient struct {
 	// Raw Http Client to do OAuth2 login.
 	httpClient *http.Client
 
-	ui util.Ui
+	ui output.Ui
 }
 
 func (m *GatewayClient) GateEndpoint() string {
@@ -98,7 +98,7 @@ func (m *GatewayClient) GateEndpoint() string {
 }
 
 // Create new spinnaker gateway client with flag
-func NewGateClient(ui util.Ui, gateEndpoint, defaultHeaders, configLocation string, ignoreCertErrors bool) (*GatewayClient, error) {
+func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation string, ignoreCertErrors bool) (*GatewayClient, error) {
 	gateClient := &GatewayClient{
 		gateEndpoint:     gateEndpoint,
 		ignoreCertErrors: ignoreCertErrors,

--- a/cmd/orca-tasks/task_watcher.go
+++ b/cmd/orca-tasks/task_watcher.go
@@ -16,9 +16,10 @@ package orca_tasks
 
 import (
 	"fmt"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"strings"
 	"time"
+
+	"github.com/spinnaker/spin/cmd/gateclient"
 )
 
 // WaitForSuccessfulTask observes an Orca task to see if it completed successfully.

--- a/cmd/output/cli_ui.go
+++ b/cmd/output/cli_ui.go
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package util
+package output
 
 import (
 	"fmt"
@@ -20,7 +20,6 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/colorstring"
-	"github.com/spinnaker/spin/cmd/output"
 )
 
 type Ui interface {
@@ -38,14 +37,12 @@ type ColorizeUi struct {
 	SuccessColor   string
 	Ui             cli.Ui
 	Quiet          bool
-	OutputFormater output.OutputFormater
+	OutputFormater OutputFormater
 }
-
-var UI *ColorizeUi
 
 func NewUI(
 	quiet, color bool,
-	outputFormater output.OutputFormater,
+	outputFormater OutputFormater,
 	outWriter, errWriter io.Writer,
 ) *ColorizeUi {
 	return &ColorizeUi{

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -15,37 +15,98 @@
 package output
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+
+	"k8s.io/client-go/util/jsonpath"
+	"sigs.k8s.io/yaml"
 )
 
-// TODO(jacobkiefer): Extend for other output formats.
-type OutputFormat struct {
-	// JsonPath specifies a subpath of the output to extract data from
-	JsonPath string
-	Yaml     bool
-	Json     bool
-}
+type OutputFormater func(interface{}) ([]byte, error)
 
-func ParseOutputFormat(outputFormat string) (*OutputFormat, error) {
-	format := new(OutputFormat)
+// ParseOutputFormat returns an OutputFormater based on the specified format.
+// Accepted values include 'json', 'yaml', and 'jsonpath=PATH'.
+// Empty string defaults to 'json'.
+// For more about JSONPath, see https://goessner.net/articles/JsonPath/
+func ParseOutputFormat(outputFormat string) (OutputFormater, error) {
 	switch {
 	case outputFormat == "" || outputFormat == "json":
-		format.Json = true
-		return format, nil
+		return MarshalToJson, nil
 	case outputFormat == "yaml":
-		format.Yaml = true
-		return format, nil
-	case strings.HasPrefix(outputFormat, "jsonpath="):
+		return MarshalToYaml, nil
+	case strings.HasPrefix(outputFormat, "jsonpath=") && outputFormat != "jsonpath=":
 		toks := strings.Split(outputFormat, "=")
 		if len(toks) != 2 {
 			return nil, errors.New(fmt.Sprintf("Failed to parse output format flag value: %s", outputFormat))
 		}
-		format.JsonPath = toks[1]
-		break
+		return MarshalToJsonPathWrapper(toks[1]), nil
 	default:
 		return nil, errors.New(fmt.Sprintf("Failed to parse output format flag value: %s", outputFormat))
 	}
-	return format, nil
+}
+
+func MarshalToJson(input interface{}) ([]byte, error) {
+	pretty, err := json.MarshalIndent(input, "", " ")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal to json: %v", err)
+	}
+	return pretty, nil
+}
+
+// MarshalToJsonPathWrapper returns a MarshalToJsonPath function that uses the
+// specified jsonpath expression.
+// This leverages the kubernetes jsonpath library
+// (https://kubernetes.io/docs/reference/kubectl/jsonpath/).
+func MarshalToJsonPathWrapper(expression string) OutputFormater {
+	expr := expression
+	// aka MarshalToJsonPath
+	return func(input interface{}) ([]byte, error) {
+		jp := jsonpath.New("json-path")
+		buffer := new(bytes.Buffer)
+
+		if err := jp.Parse(expr); err != nil {
+			return buffer.Bytes(), fmt.Errorf("Failed to parse jsonpath expression: %v", err)
+		}
+
+		err := jp.Execute(buffer, input)
+		if err != nil {
+			return buffer.Bytes(), fmt.Errorf("Failed to execute jsonpath %s on input %s: %v ", expr, input, err)
+		}
+
+		// unquote since go quotes the string if the bytes is a string.
+		return unquote(buffer.Bytes()), nil
+	}
+}
+
+func MarshalToYaml(input interface{}) ([]byte, error) {
+	pretty, err := yaml.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal to yaml: %v", err)
+	}
+	return pretty, nil
+}
+
+// TODO: is this nessesary when using bytes.Bytes() instead of bytes.String() ?
+func unquote(input []byte) []byte {
+	input = bytes.TrimLeft(input, "\"")
+	input = bytes.TrimRight(input, "\"")
+	return input
+}
+
+// parseJsonPath finds the values specified in the input data as specified with the template.
+// This leverages the kubernetes jsonpath libs (https://kubernetes.io/docs/reference/kubectl/jsonpath/).
+func parseJsonPath(input interface{}, template string) (*bytes.Buffer, error) {
+	j := jsonpath.New("json-path")
+	buf := new(bytes.Buffer)
+	if err := j.Parse(template); err != nil {
+		return buf, fmt.Errorf("Error parsing json: %v", err)
+	}
+	err := j.Execute(buf, input)
+	if err != nil {
+		return buf, fmt.Errorf("Error parsing value from input %v using template %s: %v ", input, template, err)
+	}
+	return buf, nil
 }

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -24,12 +24,16 @@ import (
 type OutputFormat struct {
 	// JsonPath specifies a subpath of the output to extract data from
 	JsonPath string
+	Yaml     bool
 }
 
 func ParseOutputFormat(outputFormat string) (*OutputFormat, error) {
 	format := new(OutputFormat)
 	switch {
 	case outputFormat == "":
+		return format, nil
+	case outputFormat == "yaml":
+		format.Yaml = true
 		return format, nil
 	case strings.HasPrefix(outputFormat, "jsonpath="):
 		toks := strings.Split(outputFormat, "=")

--- a/cmd/output/output.go
+++ b/cmd/output/output.go
@@ -25,12 +25,14 @@ type OutputFormat struct {
 	// JsonPath specifies a subpath of the output to extract data from
 	JsonPath string
 	Yaml     bool
+	Json     bool
 }
 
 func ParseOutputFormat(outputFormat string) (*OutputFormat, error) {
 	format := new(OutputFormat)
 	switch {
-	case outputFormat == "":
+	case outputFormat == "" || outputFormat == "json":
+		format.Json = true
 		return format, nil
 	case outputFormat == "yaml":
 		format.Yaml = true

--- a/cmd/output/output_test.go
+++ b/cmd/output/output_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2018, Google, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package output
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/andreyvit/diff"
+)
+
+func TestOutputMarshalToJson(t *testing.T) {
+	jsonBytes, err := MarshalToJson(testMap)
+	if err != nil {
+		t.Fatalf("Failed to format: %s", err)
+	}
+
+	expected := strings.TrimSpace(testJsonStr)
+	recieved := strings.TrimSpace(string(jsonBytes))
+  if expected != recieved {
+		t.Fatalf("Unexpected formatted yaml output (want- get+):\n%s", diff.LineDiff(expected, recieved))
+	}
+}
+
+func TestOutputMarshalToYaml(t *testing.T) {
+	yamlBytes, err := MarshalToYaml(testMap)
+	if err != nil {
+		t.Fatalf("Failed to format: %s", err)
+	}
+
+	expected := strings.TrimSpace(testYamlStr)
+	recieved := strings.TrimSpace(string(yamlBytes))
+	if expected != recieved {
+		t.Fatalf("Unexpected formatted yaml output (want- get+):\n%s", diff.LineDiff(expected, recieved))
+	}
+}
+
+func TestOutputMarshalToJsonPath_string(t *testing.T) {
+	formatFunc := MarshalToJsonPathWrapper("{.parameterConfig[0].name}")
+	jsonBytes, err := formatFunc(testMap)
+	if err != nil {
+		t.Fatalf("Failed to format: %s", err)
+	}
+
+	expected := "foo"
+	recieved := string(jsonBytes)
+	if recieved != expected {
+		t.Fatalf("Unexpected formatted jsonpath output: want=\"%s\" got=\"%s\"", expected, recieved)
+	}
+}
+
+// TODO(karlkfi): Validate non-primitive jsonpath outputs.
+// This behavior changed with https://github.com/spinnaker/spin/pull/241
+
+var testMap = map[string]interface{}{
+	"application":          "app",
+	"id":                   "pipeline1",
+	"keepWaitingPipelines": false,
+	"lastModifiedBy":       "anonymous",
+	"limitConcurrent":      true,
+	"name":                 "pipeline1",
+	"parameterConfig": []map[string]interface{}{
+		{
+			"default":     "bar",
+			"description": "A foo.",
+			"name":        "foo",
+			"required":    true,
+		},
+	},
+	"stages": []map[string]interface{}{
+		{
+			"comments":             "${ parameters.derp }",
+			"name":                 "Wait",
+			"refId":                "1",
+			"requisiteStageRefIds": []string{},
+			"type":                 "wait",
+			"waitTime":             30,
+		},
+	},
+	"triggers": []string{},
+	"updateTs": "1520879791608",
+}
+
+const testJsonPathArrayOfMapsStr = `
+[
+ {
+  "default": "bar",
+  "description": "A foo.",
+  "name": "foo",
+  "required": true
+ }
+]
+`
+
+const testJsonStr = `
+{
+ "application": "app",
+ "id": "pipeline1",
+ "keepWaitingPipelines": false,
+ "lastModifiedBy": "anonymous",
+ "limitConcurrent": true,
+ "name": "pipeline1",
+ "parameterConfig": [
+  {
+   "default": "bar",
+   "description": "A foo.",
+   "name": "foo",
+   "required": true
+  }
+ ],
+ "stages": [
+  {
+   "comments": "${ parameters.derp }",
+   "name": "Wait",
+   "refId": "1",
+   "requisiteStageRefIds": [],
+   "type": "wait",
+   "waitTime": 30
+  }
+ ],
+ "triggers": [],
+ "updateTs": "1520879791608"
+}
+`
+
+const testYamlStr = `
+application: app
+id: pipeline1
+keepWaitingPipelines: false
+lastModifiedBy: anonymous
+limitConcurrent: true
+name: pipeline1
+parameterConfig:
+- default: bar
+  description: A foo.
+  name: foo
+  required: true
+stages:
+- comments: ${ parameters.derp }
+  name: Wait
+  refId: "1"
+  requisiteStageRefIds: []
+  type: wait
+  waitTime: 30
+triggers: []
+updateTs: "1520879791608"
+`

--- a/cmd/pipeline-template/delete.go
+++ b/cmd/pipeline-template/delete.go
@@ -80,6 +80,6 @@ func deletePipelineTemplate(cmd *cobra.Command, options DeleteOptions, args []st
 		return fmt.Errorf("Encountered an error deleting pipeline template, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Pipeline template %s deleted", id)))
+	util.UI.Success(fmt.Sprintf("Pipeline template %s deleted", id))
 	return nil
 }

--- a/cmd/pipeline-template/delete.go
+++ b/cmd/pipeline-template/delete.go
@@ -16,10 +16,11 @@ package pipeline_template
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type DeleteOptions struct {
@@ -28,8 +29,8 @@ type DeleteOptions struct {
 }
 
 var (
-	deletePipelineTemplateShort   = "Delete the provided pipeline template"
-	deletePipelineTemplateLong    = "Delete the provided pipeline template"
+	deletePipelineTemplateShort = "Delete the provided pipeline template"
+	deletePipelineTemplateLong  = "Delete the provided pipeline template"
 )
 
 func NewDeleteCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {

--- a/cmd/pipeline-template/delete.go
+++ b/cmd/pipeline-template/delete.go
@@ -19,11 +19,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type DeleteOptions struct {
+type deleteOptions struct {
 	*pipelineTemplateOptions
 	tag string
 }
@@ -33,9 +32,9 @@ var (
 	deletePipelineTemplateLong  = "Delete the provided pipeline template"
 )
 
-func NewDeleteCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {
-	options := DeleteOptions{
-		pipelineTemplateOptions: &pipelineTemplateOptions,
+func NewDeleteCmd(pipelineTemplateOptions *pipelineTemplateOptions) *cobra.Command {
+	options := &deleteOptions{
+		pipelineTemplateOptions: pipelineTemplateOptions,
 	}
 
 	cmd := &cobra.Command{
@@ -54,12 +53,7 @@ func NewDeleteCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Comman
 	return cmd
 }
 
-func deletePipelineTemplate(cmd *cobra.Command, options DeleteOptions, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func deletePipelineTemplate(cmd *cobra.Command, options *deleteOptions, args []string) error {
 	id, err := util.ReadArgsOrStdin(args)
 	if err != nil {
 		return err
@@ -70,7 +64,7 @@ func deletePipelineTemplate(cmd *cobra.Command, options DeleteOptions, args []st
 		queryParams["tag"] = options.tag
 	}
 
-	_, resp, err := gateClient.V2PipelineTemplatesControllerApi.DeleteUsingDELETE1(gateClient.Context, id, queryParams)
+	_, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.DeleteUsingDELETE1(options.GateClient.Context, id, queryParams)
 
 	if err != nil {
 		return err
@@ -80,6 +74,6 @@ func deletePipelineTemplate(cmd *cobra.Command, options DeleteOptions, args []st
 		return fmt.Errorf("Encountered an error deleting pipeline template, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.Success(fmt.Sprintf("Pipeline template %s deleted", id))
+	options.Ui.Success(fmt.Sprintf("Pipeline template %s deleted", id))
 	return nil
 }

--- a/cmd/pipeline-template/delete_test.go
+++ b/cmd/pipeline-template/delete_test.go
@@ -32,13 +32,13 @@ func TestPipelineTemplateDelete_basic(t *testing.T) {
 
 	args := []string{"pipeline-template", "delete", "myTemplate", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -50,13 +50,13 @@ func TestPipelineTemplateDelete_tag(t *testing.T) {
 
 	args := []string{"pipeline-template", "delete", "myTemplate", "--tag", "stable", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -68,13 +68,13 @@ func TestPipelineTemplateDelete_fail(t *testing.T) {
 
 	args := []string{"pipeline-template", "delete", "myTemplate", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -86,13 +86,13 @@ func TestPipelineTemplateDelete_flags(t *testing.T) {
 
 	args := []string{"pipeline-template", "delete", "--id", "myTemplate", "--gate-endpoint", ts.URL} // Extra --id flag.
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -104,13 +104,13 @@ func TestPipelineTemplateDelete_missingid(t *testing.T) {
 
 	args := []string{"pipeline-template", "delete", "--gate-endpoint", ts.URL} // Missing pipeline id.
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command errantly succeeded. %s", err)
 	}

--- a/cmd/pipeline-template/delete_test.go
+++ b/cmd/pipeline-template/delete_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	gate "github.com/spinnaker/spin/gateapi"
@@ -33,7 +32,7 @@ func TestPipelineTemplateDelete_basic(t *testing.T) {
 	args := []string{"pipeline-template", "delete", "myTemplate", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -51,7 +50,7 @@ func TestPipelineTemplateDelete_tag(t *testing.T) {
 	args := []string{"pipeline-template", "delete", "myTemplate", "--tag", "stable", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -69,7 +68,7 @@ func TestPipelineTemplateDelete_fail(t *testing.T) {
 	args := []string{"pipeline-template", "delete", "myTemplate", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -87,7 +86,7 @@ func TestPipelineTemplateDelete_flags(t *testing.T) {
 	args := []string{"pipeline-template", "delete", "--id", "myTemplate", "--gate-endpoint", ts.URL} // Extra --id flag.
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -105,7 +104,7 @@ func TestPipelineTemplateDelete_missingid(t *testing.T) {
 	args := []string{"pipeline-template", "delete", "--gate-endpoint", ts.URL} // Missing pipeline id.
 	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 

--- a/cmd/pipeline-template/delete_test.go
+++ b/cmd/pipeline-template/delete_test.go
@@ -17,10 +17,12 @@ package pipeline_template
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	gate "github.com/spinnaker/spin/gateapi"
 	"github.com/spinnaker/spin/util"
 )
@@ -29,15 +31,12 @@ func TestPipelineTemplateDelete_basic(t *testing.T) {
 	ts := gateServerDeleteSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "delete", "myTemplate", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "delete", "myTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -47,15 +46,12 @@ func TestPipelineTemplateDelete_tag(t *testing.T) {
 	ts := gateServerDeleteSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "delete", "myTemplate", "--tag", "stable", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "delete", "myTemplate", "--tag", "stable", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,15 +61,12 @@ func TestPipelineTemplateDelete_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "delete", "myTemplate", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "delete", "myTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -83,15 +76,12 @@ func TestPipelineTemplateDelete_flags(t *testing.T) {
 	ts := gateServerDeleteSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "delete", "--id", "myTemplate", "--gate-endpoint", ts.URL} // Extra --id flag.
-	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "delete", "--id", "myTemplate", "--gate-endpoint", ts.URL} // Extra --id flag.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -101,15 +91,12 @@ func TestPipelineTemplateDelete_missingid(t *testing.T) {
 	ts := gateServerDeleteSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "delete", "--gate-endpoint", ts.URL} // Missing pipeline id.
-	currentCmd := NewDeleteCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "delete", "--gate-endpoint", ts.URL} // Missing pipeline id.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command errantly succeeded. %s", err)
 	}

--- a/cmd/pipeline-template/delete_test.go
+++ b/cmd/pipeline-template/delete_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestPipelineTemplateDelete_basic(t *testing.T) {
-	ts := gateServerDeleteSuccess()
+	ts := testGateDeleteSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -43,7 +43,7 @@ func TestPipelineTemplateDelete_basic(t *testing.T) {
 }
 
 func TestPipelineTemplateDelete_tag(t *testing.T) {
-	ts := gateServerDeleteSuccess()
+	ts := testGateDeleteSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -58,7 +58,7 @@ func TestPipelineTemplateDelete_tag(t *testing.T) {
 }
 
 func TestPipelineTemplateDelete_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -73,7 +73,7 @@ func TestPipelineTemplateDelete_fail(t *testing.T) {
 }
 
 func TestPipelineTemplateDelete_flags(t *testing.T) {
-	ts := gateServerDeleteSuccess()
+	ts := testGateDeleteSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -88,7 +88,7 @@ func TestPipelineTemplateDelete_flags(t *testing.T) {
 }
 
 func TestPipelineTemplateDelete_missingid(t *testing.T) {
-	ts := gateServerDeleteSuccess()
+	ts := testGateDeleteSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -102,10 +102,10 @@ func TestPipelineTemplateDelete_missingid(t *testing.T) {
 	}
 }
 
-// gateServerDeleteSuccess spins up a local http server that we will configure the GateClient
+// testGateDeleteSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with OK to indicate a pipeline template exists,
 // and Accepts POST calls.
-func gateServerDeleteSuccess() *httptest.Server {
+func testGateDeleteSuccess() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/v2/pipelineTemplates/myTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete {

--- a/cmd/pipeline-template/get.go
+++ b/cmd/pipeline-template/get.go
@@ -17,15 +17,16 @@ package pipeline_template
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type GetOptions struct {
 	*pipelineTemplateOptions
-	id string
+	id  string
 	tag string
 }
 

--- a/cmd/pipeline-template/get.go
+++ b/cmd/pipeline-template/get.go
@@ -90,6 +90,6 @@ func getPipelineTemplate(cmd *cobra.Command, options GetOptions, args []string) 
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline-template/get.go
+++ b/cmd/pipeline-template/get.go
@@ -20,11 +20,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type GetOptions struct {
+type getOptions struct {
 	*pipelineTemplateOptions
 	id  string
 	tag string
@@ -35,9 +34,9 @@ var (
 	getPipelineTemplateLong  = "Get the specified pipeline template"
 )
 
-func NewGetCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {
-	options := GetOptions{
-		pipelineTemplateOptions: &pipelineTemplateOptions,
+func NewGetCmd(pipelineTemplateOptions *pipelineTemplateOptions) *cobra.Command {
+	options := &getOptions{
+		pipelineTemplateOptions: pipelineTemplateOptions,
 	}
 	cmd := &cobra.Command{
 		Use:   "get",
@@ -55,12 +54,8 @@ func NewGetCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {
 	return cmd
 }
 
-func getPipelineTemplate(cmd *cobra.Command, options GetOptions, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func getPipelineTemplate(cmd *cobra.Command, options *getOptions, args []string) error {
+	var err error
 	id := options.id
 	if id == "" {
 		id, err = util.ReadArgsOrStdin(args)
@@ -77,7 +72,7 @@ func getPipelineTemplate(cmd *cobra.Command, options GetOptions, args []string) 
 		queryParams["tag"] = options.tag
 	}
 
-	successPayload, resp, err := gateClient.V2PipelineTemplatesControllerApi.GetUsingGET2(gateClient.Context,
+	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.GetUsingGET2(options.GateClient.Context,
 		id, queryParams)
 
 	if err != nil {
@@ -90,6 +85,6 @@ func getPipelineTemplate(cmd *cobra.Command, options GetOptions, args []string) 
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline-template/get_test.go
+++ b/cmd/pipeline-template/get_test.go
@@ -15,27 +15,27 @@ package pipeline_template
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
 func TestPipelineGet_basic(t *testing.T) {
 	ts := testGatePipelineTemplateGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
 	args := []string{"pipeline-template", "get", "--id", "newSpelTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -44,16 +44,14 @@ func TestPipelineGet_basic(t *testing.T) {
 func TestPipelineGet_args(t *testing.T) {
 	ts := testGatePipelineTemplateGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
 	args := []string{"pipeline-template", "get", "newSpelTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -62,16 +60,14 @@ func TestPipelineGet_args(t *testing.T) {
 func TestPipelineGet_tag(t *testing.T) {
 	ts := testGatePipelineTemplateGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
 	args := []string{"pipeline-template", "get", "newSpelTemplate", "--tag", "stable", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -81,16 +77,13 @@ func TestPipelineGet_flags(t *testing.T) {
 	ts := testGatePipelineTemplateGetSuccess()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
 	args := []string{"pipeline-template", "get", "--gate-endpoint", ts.URL} // missing id flag and no args
 	rootCmd.SetArgs(args)
 
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -100,16 +93,13 @@ func TestPipelineGet_malformed(t *testing.T) {
 	ts := testGatePipelineTemplateGetMalformed()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
 	args := []string{"pipeline-template", "get", "--id", "newSpelTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -119,16 +109,13 @@ func TestPipelineGet_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
 	args := []string{"pipeline-template", "get", "--id", "newSpelTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -138,16 +125,13 @@ func TestPipelineGet_notfound(t *testing.T) {
 	ts := testGatePipelineTemplateGetMissing()
 	defer ts.Close()
 
-	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
 	args := []string{"pipeline-template", "get", "--application", "app", "--name", "two", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline-template/get_test.go
+++ b/cmd/pipeline-template/get_test.go
@@ -21,28 +21,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/util"
 )
-
-func getRootCmdForTest() *cobra.Command {
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
-	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
-	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
-	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
-	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
-	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
-	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
-	util.InitUI(false, false, "")
-	return rootCmd
-}
 
 func TestPipelineGet_basic(t *testing.T) {
 	ts := testGatePipelineTemplateGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
@@ -50,7 +36,7 @@ func TestPipelineGet_basic(t *testing.T) {
 	args := []string{"pipeline-template", "get", "--id", "newSpelTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -60,7 +46,7 @@ func TestPipelineGet_args(t *testing.T) {
 	ts := testGatePipelineTemplateGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
@@ -68,7 +54,7 @@ func TestPipelineGet_args(t *testing.T) {
 	args := []string{"pipeline-template", "get", "newSpelTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -78,7 +64,7 @@ func TestPipelineGet_tag(t *testing.T) {
 	ts := testGatePipelineTemplateGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
@@ -86,7 +72,7 @@ func TestPipelineGet_tag(t *testing.T) {
 	args := []string{"pipeline-template", "get", "newSpelTemplate", "--tag", "stable", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -97,7 +83,7 @@ func TestPipelineGet_flags(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
@@ -105,7 +91,7 @@ func TestPipelineGet_flags(t *testing.T) {
 	args := []string{"pipeline-template", "get", "--gate-endpoint", ts.URL} // missing id flag and no args
 	rootCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -116,7 +102,7 @@ func TestPipelineGet_malformed(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
@@ -124,7 +110,7 @@ func TestPipelineGet_malformed(t *testing.T) {
 	args := []string{"pipeline-template", "get", "--id", "newSpelTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -135,7 +121,7 @@ func TestPipelineGet_fail(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
@@ -143,7 +129,7 @@ func TestPipelineGet_fail(t *testing.T) {
 	args := []string{"pipeline-template", "get", "--id", "newSpelTemplate", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -154,7 +140,7 @@ func TestPipelineGet_notfound(t *testing.T) {
 	defer ts.Close()
 
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
@@ -162,7 +148,7 @@ func TestPipelineGet_notfound(t *testing.T) {
 	args := []string{"pipeline-template", "get", "--application", "app", "--name", "two", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
 
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline-template/get_test.go
+++ b/cmd/pipeline-template/get_test.go
@@ -14,6 +14,7 @@
 package pipeline_template
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -21,15 +22,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/andreyvit/diff"
 	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
-func TestPipelineGet_basic(t *testing.T) {
+func TestPipelineGet_json(t *testing.T) {
 	ts := testGatePipelineTemplateGetSuccess()
 	defer ts.Close()
 
-	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	buffer := new(bytes.Buffer)
+	rootCmd, rootOpts := cmd.NewCmdRoot(buffer, buffer)
 	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
 	args := []string{"pipeline-template", "get", "--id", "newSpelTemplate", "--gate-endpoint", ts.URL}
@@ -38,6 +41,35 @@ func TestPipelineGet_basic(t *testing.T) {
 	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(pipelineTemplateGetJson)
+	recieved := strings.TrimSpace(buffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected command output:\n%s", diff.LineDiff(expected, recieved))
+	}
+}
+
+func TestPipelineGet_yaml(t *testing.T) {
+	ts := testGatePipelineTemplateGetSuccess()
+	defer ts.Close()
+
+	buffer := new(bytes.Buffer)
+	rootCmd, rootOpts := cmd.NewCmdRoot(buffer, buffer)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
+
+	args := []string{"pipeline-template", "get", "--id", "newSpelTemplate", "--output", "yaml", "--gate-endpoint", ts.URL}
+	rootCmd.SetArgs(args)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(pipelineTemplateGetYaml)
+	recieved := strings.TrimSpace(buffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected command output:\n%s", diff.LineDiff(expected, recieved))
 	}
 }
 
@@ -106,7 +138,7 @@ func TestPipelineGet_malformed(t *testing.T) {
 }
 
 func TestPipelineGet_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -165,9 +197,9 @@ func testGatePipelineTemplateGetMissing() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// GateServerFail spins up a local http server that we will configure the GateClient
+// testGateFail spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 500 InternalServerError.
-func GateServerFail() *httptest.Server {
+func testGateFail() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -283,4 +315,46 @@ const pipelineTemplateGetJson = `
   }
  ]
 }
+`
+
+const pipelineTemplateGetYaml = `
+id: newSpelTemplate
+lastModifiedBy: anonymous
+metadata:
+  description: A generic application bake and tag pipeline.
+  name: Default Bake and Tag
+  owner: example@example.com
+  scopes:
+  - global
+pipeline:
+  description: ""
+  keepWaitingPipelines: false
+  lastModifiedBy: anonymous
+  limitConcurrent: true
+  notifications: []
+  parameterConfig: []
+  stages:
+  - name: My Wait Stage
+    refId: wait1
+    requisiteStageRefIds: []
+    type: wait
+    waitTime: ${ templateVariables.waitTime }
+  triggers:
+  - attributeConstraints: {}
+    enabled: true
+    payloadConstraints: {}
+    pubsubSystem: google
+    source: jtk54
+    subscription: super-pub
+    subscriptionName: super-pub
+    type: pubsub
+  updateTs: "1543509523663"
+protect: false
+schema: v2
+updateTs: "1543860678988"
+variables:
+- defaultValue: 42
+  description: The time a wait stage shall pauseth
+  name: waitTime
+  type: int
 `

--- a/cmd/pipeline-template/get_test.go
+++ b/cmd/pipeline-template/get_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestPipelineGet_basic(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -47,7 +46,7 @@ func TestPipelineGet_args(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -65,7 +64,7 @@ func TestPipelineGet_tag(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -84,7 +83,7 @@ func TestPipelineGet_flags(t *testing.T) {
 
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -103,7 +102,7 @@ func TestPipelineGet_malformed(t *testing.T) {
 
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -122,7 +121,7 @@ func TestPipelineGet_fail(t *testing.T) {
 
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -141,7 +140,7 @@ func TestPipelineGet_notfound(t *testing.T) {
 
 	currentCmd := NewGetCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 

--- a/cmd/pipeline-template/list.go
+++ b/cmd/pipeline-template/list.go
@@ -72,6 +72,6 @@ func listPipelineTemplate(cmd *cobra.Command, options ListOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline-template/list.go
+++ b/cmd/pipeline-template/list.go
@@ -19,11 +19,9 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 )
 
-type ListOptions struct {
+type listOptions struct {
 	*pipelineTemplateOptions
 	scopes *[]string
 }
@@ -33,9 +31,9 @@ var (
 	listPipelineTemplateLong  = "List the pipeline templates for the provided scopes"
 )
 
-func NewListCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {
-	options := ListOptions{
-		pipelineTemplateOptions: &pipelineTemplateOptions,
+func NewListCmd(pipelineTemplateOptions *pipelineTemplateOptions) *cobra.Command {
+	options := &listOptions{
+		pipelineTemplateOptions: pipelineTemplateOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -53,13 +51,8 @@ func NewListCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command 
 	return cmd
 }
 
-func listPipelineTemplate(cmd *cobra.Command, options ListOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
-	successPayload, resp, err := gateClient.V2PipelineTemplatesControllerApi.ListUsingGET1(gateClient.Context,
+func listPipelineTemplate(cmd *cobra.Command, options *listOptions) error {
+	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.ListUsingGET1(options.GateClient.Context,
 		map[string]interface{}{"scopes": options.scopes})
 
 	if err != nil {
@@ -72,6 +65,6 @@ func listPipelineTemplate(cmd *cobra.Command, options ListOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline-template/list_test.go
+++ b/cmd/pipeline-template/list_test.go
@@ -16,11 +16,13 @@ package pipeline_template
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,15 +30,12 @@ func TestPipelineTemplateList_basic(t *testing.T) {
 	ts := testGatePipelineTemplateListSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -46,15 +45,12 @@ func TestPipelineTemplateList_scope(t *testing.T) {
 	ts := testGateScopedPipelineTemplateListSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "list", "--scopes", "specific", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "list", "--scopes", "specific", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -64,15 +60,12 @@ func TestPipelineTemplateList_malformed(t *testing.T) {
 	ts := testGatePipelineTemplateListMalformed()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -82,15 +75,12 @@ func TestPipelineTemplateList_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline-template/list_test.go
+++ b/cmd/pipeline-template/list_test.go
@@ -72,7 +72,7 @@ func TestPipelineTemplateList_malformed(t *testing.T) {
 }
 
 func TestPipelineTemplateList_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)

--- a/cmd/pipeline-template/list_test.go
+++ b/cmd/pipeline-template/list_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestPipelineTemplateList_basic(t *testing.T) {
 	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -50,7 +49,7 @@ func TestPipelineTemplateList_scope(t *testing.T) {
 	args := []string{"pipeline-template", "list", "--scopes", "specific", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -68,7 +67,7 @@ func TestPipelineTemplateList_malformed(t *testing.T) {
 	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -86,7 +85,7 @@ func TestPipelineTemplateList_fail(t *testing.T) {
 	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 

--- a/cmd/pipeline-template/list_test.go
+++ b/cmd/pipeline-template/list_test.go
@@ -31,13 +31,13 @@ func TestPipelineTemplateList_basic(t *testing.T) {
 
 	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -49,13 +49,13 @@ func TestPipelineTemplateList_scope(t *testing.T) {
 
 	args := []string{"pipeline-template", "list", "--scopes", "specific", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -67,13 +67,13 @@ func TestPipelineTemplateList_malformed(t *testing.T) {
 
 	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -85,13 +85,13 @@ func TestPipelineTemplateList_fail(t *testing.T) {
 
 	args := []string{"pipeline-template", "list", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline-template/pipeline_template.go
+++ b/cmd/pipeline-template/pipeline_template.go
@@ -15,8 +15,6 @@
 package pipeline_template
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +26,7 @@ var (
 	pipelineTemplateExample = ""
 )
 
-func NewPipelineTemplateCmd(out io.Writer) *cobra.Command {
+func NewPipelineTemplateCmd() *cobra.Command {
 	options := pipelineTemplateOptions{}
 	cmd := &cobra.Command{
 		Use:     "pipeline-template",

--- a/cmd/pipeline-template/pipeline_template.go
+++ b/cmd/pipeline-template/pipeline_template.go
@@ -16,9 +16,12 @@ package pipeline_template
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd"
 )
 
-type pipelineTemplateOptions struct{}
+type pipelineTemplateOptions struct {
+	*cmd.RootOptions
+}
 
 var (
 	pipelineTemplateShort   = ""
@@ -26,8 +29,10 @@ var (
 	pipelineTemplateExample = ""
 )
 
-func NewPipelineTemplateCmd() *cobra.Command {
-	options := pipelineTemplateOptions{}
+func NewPipelineTemplateCmd(rootOptions *cmd.RootOptions) *cobra.Command {
+	options := &pipelineTemplateOptions{
+		RootOptions: rootOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "pipeline-template",
 		Aliases: []string{"pipeline-templates", "pt"},

--- a/cmd/pipeline-template/plan.go
+++ b/cmd/pipeline-template/plan.go
@@ -20,11 +20,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type PlanOptions struct {
+type planOptions struct {
 	*pipelineTemplateOptions
 	configPath string
 }
@@ -34,9 +33,9 @@ const (
 	planPipelineTemplateLong  = "Plan the provided pipeline template config"
 )
 
-func NewPlanCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {
-	options := PlanOptions{
-		pipelineTemplateOptions: &pipelineTemplateOptions,
+func NewPlanCmd(pipelineTemplateOptions *pipelineTemplateOptions) *cobra.Command {
+	options := &planOptions{
+		pipelineTemplateOptions: pipelineTemplateOptions,
 	}
 	cmd := &cobra.Command{
 		Use:   "plan",
@@ -52,12 +51,7 @@ func NewPlanCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command 
 	return cmd
 }
 
-func planPipelineTemplate(cmd *cobra.Command, options PlanOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func planPipelineTemplate(cmd *cobra.Command, options *planOptions) error {
 	configJson, err := util.ParseJsonFromFileOrStdin(options.configPath, false)
 	if err != nil {
 		return err
@@ -67,7 +61,7 @@ func planPipelineTemplate(cmd *cobra.Command, options PlanOptions) error {
 		return errors.New("Required pipeline key 'schema' missing for templated pipeline config...\n")
 	}
 
-	successPayload, resp, err := gateClient.V2PipelineTemplatesControllerApi.PlanUsingPOST(gateClient.Context, configJson)
+	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.PlanUsingPOST(options.GateClient.Context, configJson)
 
 	if err != nil {
 		return err
@@ -78,6 +72,6 @@ func planPipelineTemplate(cmd *cobra.Command, options PlanOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline-template/plan.go
+++ b/cmd/pipeline-template/plan.go
@@ -17,10 +17,11 @@ package pipeline_template
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type PlanOptions struct {

--- a/cmd/pipeline-template/plan.go
+++ b/cmd/pipeline-template/plan.go
@@ -78,6 +78,6 @@ func planPipelineTemplate(cmd *cobra.Command, options PlanOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline-template/plan_test.go
+++ b/cmd/pipeline-template/plan_test.go
@@ -38,7 +38,7 @@ func TestPipelineTemplatePlan_basic(t *testing.T) {
 
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -68,7 +68,7 @@ func TestPipelineTemplatePlan_stdin(t *testing.T) {
 	args := []string{"pipeline-template", "plan", "--gate-endpoint", ts.URL}
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -92,7 +92,7 @@ func TestPipelineTemplatePlan_fail(t *testing.T) {
 	args := []string{"pipeline-template", "plan", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -110,7 +110,7 @@ func TestPipelineTemplatePlan_flags(t *testing.T) {
 	args := []string{"pipeline-template", "plan", "--gate-endpoint", ts.URL} // Missing pipeline config file and stdin.
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 

--- a/cmd/pipeline-template/plan_test.go
+++ b/cmd/pipeline-template/plan_test.go
@@ -16,12 +16,14 @@ package pipeline_template
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -34,16 +36,13 @@ func TestPipelineTemplatePlan_basic(t *testing.T) {
 		t.Fatal("Could not create temp pipeline template file.")
 	}
 	defer os.Remove(tempFile.Name())
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
+
 	args := []string{"pipeline-template", "plan", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-
-	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,15 +64,12 @@ func TestPipelineTemplatePlan_stdin(t *testing.T) {
 	defer func() { os.Stdin = oldStdin }()
 	os.Stdin = tempFile
 
-	args := []string{"pipeline-template", "plan", "--gate-endpoint", ts.URL}
-	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "plan", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -89,15 +85,12 @@ func TestPipelineTemplatePlan_fail(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline-template", "plan", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "plan", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Expected failure but command succeeded")
 	}
@@ -107,15 +100,12 @@ func TestPipelineTemplatePlan_flags(t *testing.T) {
 	ts := gateServerPlanSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "plan", "--gate-endpoint", ts.URL} // Missing pipeline config file and stdin.
-	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "plan", "--gate-endpoint", ts.URL} // Missing pipeline config file and stdin.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Expected failure but command succeeded")
 	}

--- a/cmd/pipeline-template/plan_test.go
+++ b/cmd/pipeline-template/plan_test.go
@@ -37,13 +37,13 @@ func TestPipelineTemplatePlan_basic(t *testing.T) {
 	args := []string{"pipeline-template", "plan", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -67,13 +67,13 @@ func TestPipelineTemplatePlan_stdin(t *testing.T) {
 
 	args := []string{"pipeline-template", "plan", "--gate-endpoint", ts.URL}
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -91,13 +91,13 @@ func TestPipelineTemplatePlan_fail(t *testing.T) {
 
 	args := []string{"pipeline-template", "plan", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Expected failure but command succeeded")
 	}
@@ -109,13 +109,13 @@ func TestPipelineTemplatePlan_flags(t *testing.T) {
 
 	args := []string{"pipeline-template", "plan", "--gate-endpoint", ts.URL} // Missing pipeline config file and stdin.
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Expected failure but command succeeded")
 	}
@@ -223,11 +223,11 @@ const testPlanConfig = `
             "enabled": true,
             "pubsubSystem": "google",
             "subscription": "super-derp",
-            "subscription": "super-derp",
             "subscriptionName": "super-derp",
             "source": "jack",
             "attributeConstraints": {},
-            "payloadConstraints": {}
+            "payloadConstraints": {},
+						"invalid-key": "whatever"
         }
     ],
     "parameters": [],

--- a/cmd/pipeline-template/plan_test.go
+++ b/cmd/pipeline-template/plan_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestPipelineTemplatePlan_basic(t *testing.T) {
-	ts := gateServerPlanSuccess()
+	ts := testGatePlanSuccess()
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPlanConfig)
@@ -49,7 +49,7 @@ func TestPipelineTemplatePlan_basic(t *testing.T) {
 }
 
 func TestPipelineTemplatePlan_stdin(t *testing.T) {
-	ts := gateServerPlanSuccess()
+	ts := testGatePlanSuccess()
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPlanConfig)
@@ -76,7 +76,7 @@ func TestPipelineTemplatePlan_stdin(t *testing.T) {
 }
 
 func TestPipelineTemplatePlan_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPlanConfig)
@@ -97,7 +97,7 @@ func TestPipelineTemplatePlan_fail(t *testing.T) {
 }
 
 func TestPipelineTemplatePlan_flags(t *testing.T) {
-	ts := gateServerPlanSuccess()
+	ts := testGatePlanSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -111,10 +111,10 @@ func TestPipelineTemplatePlan_flags(t *testing.T) {
 	}
 }
 
-// gateServerUpdateSuccess spins up a local http server that we will configure the GateClient
+// testGatePlanSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with 404 NotFound to indicate a pipeline template doesn't exist,
 // and Accepts POST calls.
-func gateServerPlanSuccess() *httptest.Server {
+func testGatePlanSuccess() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/v2/pipelineTemplates/plan", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {

--- a/cmd/pipeline-template/save.go
+++ b/cmd/pipeline-template/save.go
@@ -16,22 +16,23 @@ package pipeline_template
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 type SaveOptions struct {
 	*pipelineTemplateOptions
 	output       string
 	templateFile string
-	tag string
+	tag          string
 }
 
 var (
-	saveTemplateShort   = "Save the provided pipeline template"
-	saveTemplateLong    = "Save the provided pipeline template"
+	saveTemplateShort = "Save the provided pipeline template"
+	saveTemplateLong  = "Save the provided pipeline template"
 )
 
 func NewSaveCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {
@@ -97,14 +98,14 @@ func savePipelineTemplate(cmd *cobra.Command, options SaveOptions) error {
 		saveResp, saveErr = gateClient.V2PipelineTemplatesControllerApi.CreateUsingPOST1(gateClient.Context, templateJson, queryParams)
 	} else {
 		if queryErr != nil {
-      return queryErr
+			return queryErr
 		}
 		return fmt.Errorf("Encountered an unexpected status code %d querying pipeline template with id %s\n",
 			resp.StatusCode, templateId)
 	}
 
 	if saveErr != nil {
-    return saveErr
+		return saveErr
 	}
 
 	if saveResp.StatusCode != http.StatusAccepted {

--- a/cmd/pipeline-template/save.go
+++ b/cmd/pipeline-template/save.go
@@ -114,6 +114,6 @@ func savePipelineTemplate(cmd *cobra.Command, options SaveOptions) error {
 			saveResp.StatusCode)
 	}
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Pipeline template save succeeded")))
+	util.UI.Success("Pipeline template save succeeded")
 	return nil
 }

--- a/cmd/pipeline-template/save_test.go
+++ b/cmd/pipeline-template/save_test.go
@@ -37,13 +37,13 @@ func TestPipelineTemplateSave_create(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -61,13 +61,13 @@ func TestPipelineTemplateSave_createtag(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--tag", "stable", "--gate-endpoint", ts.URL}
 
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -85,13 +85,13 @@ func TestPipelineTemplateSave_update(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -109,13 +109,13 @@ func TestPipelineTemplateSave_updatetag(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--tag", "stable", "--gate-endpoint", ts.URL}
 
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -139,13 +139,13 @@ func TestPipelineTemplateSave_stdin(t *testing.T) {
 
 	args := []string{"pipeline-template", "save", "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -163,13 +163,13 @@ func TestPipelineTemplateSave_fail(t *testing.T) {
 
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -181,13 +181,13 @@ func TestPipelineTemplateSave_flags(t *testing.T) {
 
 	args := []string{"pipeline-template", "save", "--gate-endpoint", ts.URL} // Missing pipeline spec file and stdin.
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -205,13 +205,13 @@ func TestPipelineTemplateSave_missingid(t *testing.T) {
 
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -229,13 +229,13 @@ func TestPipelineTemplateSave_missingschema(t *testing.T) {
 
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline-template/save_test.go
+++ b/cmd/pipeline-template/save_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -34,16 +35,13 @@ func TestPipelineTemplateSave_create(t *testing.T) {
 		t.Fatal("Could not create temp pipeline template file.")
 	}
 	defer os.Remove(tempFile.Name())
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
+
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -58,16 +56,13 @@ func TestPipelineTemplateSave_createtag(t *testing.T) {
 		t.Fatal("Could not create temp pipeline template file.")
 	}
 	defer os.Remove(tempFile.Name())
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
+
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--tag", "stable", "--gate-endpoint", ts.URL}
-
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -82,16 +77,13 @@ func TestPipelineTemplateSave_update(t *testing.T) {
 		t.Fatal("Could not create temp pipeline template file.")
 	}
 	defer os.Remove(tempFile.Name())
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
+
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -106,16 +98,13 @@ func TestPipelineTemplateSave_updatetag(t *testing.T) {
 		t.Fatal("Could not create temp pipeline template file.")
 	}
 	defer os.Remove(tempFile.Name())
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
+
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--tag", "stable", "--gate-endpoint", ts.URL}
-
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
-
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -137,15 +126,12 @@ func TestPipelineTemplateSave_stdin(t *testing.T) {
 	defer func() { os.Stdin = oldStdin }()
 	os.Stdin = tempFile
 
-	args := []string{"pipeline-template", "save", "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "save", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -161,15 +147,13 @@ func TestPipelineTemplateSave_fail(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
+
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -179,15 +163,12 @@ func TestPipelineTemplateSave_flags(t *testing.T) {
 	ts := gateServerUpdateSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline-template", "save", "--gate-endpoint", ts.URL} // Missing pipeline spec file and stdin.
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "save", "--gate-endpoint", ts.URL} // Missing pipeline spec file and stdin.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -203,15 +184,12 @@ func TestPipelineTemplateSave_missingid(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -227,15 +205,12 @@ func TestPipelineTemplateSave_missingschema(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd()
-	pipelineTemplateCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(pipelineTemplateCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
 
+	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline-template/save_test.go
+++ b/cmd/pipeline-template/save_test.go
@@ -38,7 +38,7 @@ func TestPipelineTemplateSave_create(t *testing.T) {
 
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -62,7 +62,7 @@ func TestPipelineTemplateSave_createtag(t *testing.T) {
 
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -86,7 +86,7 @@ func TestPipelineTemplateSave_update(t *testing.T) {
 
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -110,7 +110,7 @@ func TestPipelineTemplateSave_updatetag(t *testing.T) {
 
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -140,7 +140,7 @@ func TestPipelineTemplateSave_stdin(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -164,7 +164,7 @@ func TestPipelineTemplateSave_fail(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -182,7 +182,7 @@ func TestPipelineTemplateSave_flags(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--gate-endpoint", ts.URL} // Missing pipeline spec file and stdin.
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -206,7 +206,7 @@ func TestPipelineTemplateSave_missingid(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -230,7 +230,7 @@ func TestPipelineTemplateSave_missingschema(t *testing.T) {
 	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 

--- a/cmd/pipeline-template/save_test.go
+++ b/cmd/pipeline-template/save_test.go
@@ -15,19 +15,23 @@
 package pipeline_template
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
-func TestPipelineTemplateSave_create(t *testing.T) {
-	ts := gateServerCreateSuccess()
+func TestPipelineTemplateSave_createjson(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateCreateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPipelineTemplateJsonStr)
@@ -45,10 +49,41 @@ func TestPipelineTemplateSave_create(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testPipelineTemplateJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
+}
+
+func TestPipelineTemplateSave_createyaml(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateCreateSuccess(saveBuffer)
+	defer ts.Close()
+
+	tempFile := tempPipelineTemplateFile(testPipelineTemplateYamlStr)
+	if tempFile == nil {
+		t.Fatal("Could not create temp pipeline template file.")
+	}
+	defer os.Remove(tempFile.Name())
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewPipelineTemplateCmd(rootOpts))
+
+	args := []string{"pipeline-template", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(testPipelineTemplateJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestPipelineTemplateSave_createtag(t *testing.T) {
-	ts := gateServerCreateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateCreateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPipelineTemplateJsonStr)
@@ -66,10 +101,15 @@ func TestPipelineTemplateSave_createtag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testPipelineTemplateJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestPipelineTemplateSave_update(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPipelineTemplateJsonStr)
@@ -87,10 +127,15 @@ func TestPipelineTemplateSave_update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testPipelineTemplateJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestPipelineTemplateSave_updatetag(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPipelineTemplateJsonStr)
@@ -108,10 +153,15 @@ func TestPipelineTemplateSave_updatetag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testPipelineTemplateJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestPipelineTemplateSave_stdin(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPipelineTemplateJsonStr)
@@ -135,10 +185,14 @@ func TestPipelineTemplateSave_stdin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testPipelineTemplateJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestPipelineTemplateSave_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(testPipelineTemplateJsonStr)
@@ -160,7 +214,8 @@ func TestPipelineTemplateSave_fail(t *testing.T) {
 }
 
 func TestPipelineTemplateSave_flags(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -172,10 +227,17 @@ func TestPipelineTemplateSave_flags(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := ""
+	recieved := strings.TrimSpace(saveBuffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected save request body:\n%s", recieved)
+	}
 }
 
 func TestPipelineTemplateSave_missingid(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(missingIdJsonStr)
@@ -193,10 +255,17 @@ func TestPipelineTemplateSave_missingid(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := ""
+	recieved := strings.TrimSpace(saveBuffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected save request body:\n%s", recieved)
+	}
 }
 
 func TestPipelineTemplateSave_missingschema(t *testing.T) {
-	ts := gateServerUpdateSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineTemplateUpdateSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineTemplateFile(missingSchemaJsonStr)
@@ -214,6 +283,12 @@ func TestPipelineTemplateSave_missingschema(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := ""
+	recieved := strings.TrimSpace(saveBuffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected save request body:\n%s", recieved)
+	}
 }
 
 func tempPipelineTemplateFile(pipelineContent string) *os.File {
@@ -226,18 +301,16 @@ func tempPipelineTemplateFile(pipelineContent string) *os.File {
 	return tempFile
 }
 
-// gateServerUpdateSuccess spins up a local http server that we will configure the GateClient
+// testGatePipelineTemplateUpdateSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with OK to indicate a pipeline template exists,
 // and Accepts POST calls.
-func gateServerUpdateSuccess() *httptest.Server {
+// Writes request body to buffer for testing.
+func testGatePipelineTemplateUpdateSuccess(buffer io.Writer) *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
-	mux.Handle("/v2/pipelineTemplates/update/testSpelTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			w.WriteHeader(http.StatusAccepted)
-		} else {
-			w.WriteHeader(http.StatusOK)
-		}
-	}))
+	mux.Handle(
+		"/v2/pipelineTemplates/update/testSpelTemplate",
+		util.NewTestBufferHandlerFunc(http.MethodPost, buffer, http.StatusAccepted, ""),
+	)
 	// Return that we found an MPT to signal that we should update.
 	mux.Handle("/v2/pipelineTemplates/testSpelTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -245,18 +318,16 @@ func gateServerUpdateSuccess() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// gateServerCreateSuccess spins up a local http server that we will configure the GateClient
+// testGatePipelineTemplateCreateSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with 404 NotFound to indicate a pipeline template doesn't exist,
 // and Accepts POST calls.
-func gateServerCreateSuccess() *httptest.Server {
+// Writes request body to buffer for testing.
+func testGatePipelineTemplateCreateSuccess(buffer io.Writer) *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
-	mux.Handle("/v2/pipelineTemplates/create", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			w.WriteHeader(http.StatusAccepted)
-		} else {
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
+	mux.Handle(
+		"/v2/pipelineTemplates/create",
+		util.NewTestBufferHandlerFunc(http.MethodPost, buffer, http.StatusAccepted, ""),
+	)
 	// Return that there are no existing MPTs.
 	mux.Handle("/v2/pipelineTemplates/testSpelTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -428,4 +499,46 @@ const testPipelineTemplateJsonStr = `
   }
  ]
 }
+`
+
+const testPipelineTemplateYamlStr = `
+id: testSpelTemplate
+lastModifiedBy: anonymous
+metadata:
+  description: A generic application bake and tag pipeline.
+  name: Default Bake and Tag
+  owner: example@example.com
+  scopes:
+  - global
+pipeline:
+  description: ''
+  keepWaitingPipelines: false
+  lastModifiedBy: anonymous
+  limitConcurrent: true
+  notifications: []
+  parameterConfig: []
+  stages:
+  - name: My Wait Stage
+    refId: wait1
+    requisiteStageRefIds: []
+    type: wait
+    waitTime: "${ templateVariables.waitTime }"
+  triggers:
+  - attributeConstraints: {}
+    enabled: true
+    payloadConstraints: {}
+    pubsubSystem: google
+    source: jake
+    subscription: super-why
+    subscriptionName: super-why
+    type: pubsub
+  updateTs: '1543509523663'
+protect: false
+schema: v2
+updateTs: '1544475186050'
+variables:
+- defaultValue: 42
+  description: The time a wait stage shall pauseth
+  name: waitTime
+  type: int
 `

--- a/cmd/pipeline-template/use.go
+++ b/cmd/pipeline-template/use.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/util"
 	"github.com/spinnaker/spin/cmd/output"
+	"github.com/spinnaker/spin/util"
 	"sigs.k8s.io/yaml"
 )
 
@@ -92,7 +92,7 @@ func usePipelineTemplate(cmd *cobra.Command, options UseOptions, args []string) 
 	if err != nil {
 		return err
 	}
-	util.InitUI(false, false, &output.OutputFormat{Json: true})
+	util.InitUI(false, false, output.MarshalToJson)
 	util.UI.JsonOutput(pipeline)
 
 	return nil

--- a/cmd/pipeline-template/use.go
+++ b/cmd/pipeline-template/use.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/util"
+	"github.com/spinnaker/spin/cmd/output"
 	"sigs.k8s.io/yaml"
 )
 
@@ -91,7 +92,7 @@ func usePipelineTemplate(cmd *cobra.Command, options UseOptions, args []string) 
 	if err != nil {
 		return err
 	}
-	util.InitUI(false, false, "")
+	util.InitUI(false, false, &output.OutputFormat{Json: true})
 	util.UI.JsonOutput(pipeline)
 
 	return nil

--- a/cmd/pipeline-template/use.go
+++ b/cmd/pipeline-template/use.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/output"
+	//"github.com/spinnaker/spin/cmd/output"
 	"github.com/spinnaker/spin/util"
 	"sigs.k8s.io/yaml"
 )
 
-type UseOptions struct {
+type useOptions struct {
 	*pipelineTemplateOptions
 	id              string
 	tag             string
@@ -45,9 +45,9 @@ const (
 	usePipelineTemplateLong  = "Creates a pipeline configuration using a managed pipeline template"
 )
 
-func NewUseCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {
-	options := UseOptions{
-		pipelineTemplateOptions: &pipelineTemplateOptions,
+func NewUseCmd(pipelineTemplateOptions *pipelineTemplateOptions) *cobra.Command {
+	options := &useOptions{
+		pipelineTemplateOptions: pipelineTemplateOptions,
 	}
 	cmd := &cobra.Command{
 		Use:   "use",
@@ -71,7 +71,7 @@ func NewUseCmd(pipelineTemplateOptions pipelineTemplateOptions) *cobra.Command {
 	return cmd
 }
 
-func usePipelineTemplate(cmd *cobra.Command, options UseOptions, args []string) error {
+func usePipelineTemplate(cmd *cobra.Command, options *useOptions, args []string) error {
 	id, errID := getTemplateID(options, args)
 	if errID != nil {
 		return errID
@@ -92,13 +92,14 @@ func usePipelineTemplate(cmd *cobra.Command, options UseOptions, args []string) 
 	if err != nil {
 		return err
 	}
-	util.InitUI(false, false, output.MarshalToJson)
-	util.UI.JsonOutput(pipeline)
+	// TODO: why is this here???
+	// util.InitUI(false, false, output.MarshalToJson)
+	options.Ui.JsonOutput(pipeline)
 
 	return nil
 }
 
-func getTemplateID(options UseOptions, args []string) (string, error) {
+func getTemplateID(options *useOptions, args []string) (string, error) {
 	// Check options if they passed in like --id
 	optionsID := strings.TrimSpace(options.id)
 	if optionsID != "" {
@@ -117,7 +118,7 @@ func getTemplateID(options UseOptions, args []string) (string, error) {
 	return argsID, nil
 }
 
-func buildUsingTemplate(id string, options UseOptions) (map[string]interface{}, error) {
+func buildUsingTemplate(id string, options *useOptions) (map[string]interface{}, error) {
 	pipeline := make(map[string]interface{})
 
 	// get variables from cmd and files
@@ -151,7 +152,7 @@ func buildUsingTemplate(id string, options UseOptions) (map[string]interface{}, 
 	return pipeline, nil
 }
 
-func getVariables(options UseOptions) (map[string]string, error) {
+func getVariables(options *useOptions) (map[string]string, error) {
 	// Create map for variables
 	var variables map[string]string
 

--- a/cmd/pipeline-template/use.go
+++ b/cmd/pipeline-template/use.go
@@ -92,8 +92,7 @@ func usePipelineTemplate(cmd *cobra.Command, options *useOptions, args []string)
 	if err != nil {
 		return err
 	}
-	// TODO: why is this here???
-	// util.InitUI(false, false, output.MarshalToJson)
+
 	options.Ui.JsonOutput(pipeline)
 
 	return nil

--- a/cmd/pipeline-template/use.go
+++ b/cmd/pipeline-template/use.go
@@ -92,7 +92,7 @@ func usePipelineTemplate(cmd *cobra.Command, options UseOptions, args []string) 
 		return err
 	}
 	util.InitUI(false, false, "")
-	util.UI.JsonOutput(pipeline, util.UI.OutputFormat)
+	util.UI.JsonOutput(pipeline)
 
 	return nil
 }

--- a/cmd/pipeline-template/use_test.go
+++ b/cmd/pipeline-template/use_test.go
@@ -32,7 +32,7 @@ var testDescription = "test-description"
 var testVariables = "one=1,two=2,three=3,four=4"
 
 func TestPipelineTemplateUse_basic(t *testing.T) {
-	ts := gateServerVersionSuccess()
+	ts := testGateVersionSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -54,7 +54,7 @@ func TestPipelineTemplateUse_basic(t *testing.T) {
 }
 
 func TestPipelineTemplateUse_basicShort(t *testing.T) {
-	ts := gateServerVersionSuccess()
+	ts := testGateVersionSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -76,7 +76,7 @@ func TestPipelineTemplateUse_basicShort(t *testing.T) {
 }
 
 func TestPipelineTemplateUse_missingFlags(t *testing.T) {
-	ts := gateServerVersionSuccess()
+	ts := testGateVersionSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -95,7 +95,7 @@ func TestPipelineTemplateUse_missingFlags(t *testing.T) {
 }
 
 func TestPipelineTemplateUse_templateVariables(t *testing.T) {
-	ts := gateServerVersionSuccess()
+	ts := testGateVersionSuccess()
 	defer ts.Close()
 
 	tempDir, tempFiles := createTestValuesFiles()
@@ -125,9 +125,9 @@ func TestPipelineTemplateUse_templateVariables(t *testing.T) {
 	}
 }
 
-// gateServerVersionSuccess spins up a local http server that we will configure the GateClient
+// testGateVersionSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds healthy to the version endpoint only.
-func gateServerVersionSuccess() *httptest.Server {
+func testGateVersionSuccess() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	return httptest.NewServer(mux)
 }

--- a/cmd/pipeline-template/use_test.go
+++ b/cmd/pipeline-template/use_test.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 var testAppName = "test-application"
@@ -34,13 +36,13 @@ func TestPipelineTemplateUse_basic(t *testing.T) {
 		fmt.Sprintf("--set=%s", testVariables)}
 
 	currentCmd := NewUseCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -53,13 +55,13 @@ func TestPipelineTemplateUse_basicShort(t *testing.T) {
 		fmt.Sprintf("--set=%s", testVariables)}
 
 	currentCmd := NewUseCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -68,13 +70,13 @@ func TestPipelineTemplateUse_basicShort(t *testing.T) {
 func TestPipelineTemplateUse_missingFlags(t *testing.T) {
 	args := []string{"pipeline-template", "use"} // Missing id, application, name
 	currentCmd := NewUseCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Expected failure but command succeeded")
 	}
@@ -96,13 +98,13 @@ func TestPipelineTemplateUse_templateVariables(t *testing.T) {
 		fmt.Sprintf("--set=%s", testVariables)}
 
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline-template/use_test.go
+++ b/cmd/pipeline-template/use_test.go
@@ -37,7 +37,7 @@ func TestPipelineTemplateUse_basic(t *testing.T) {
 
 	currentCmd := NewUseCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -56,7 +56,7 @@ func TestPipelineTemplateUse_basicShort(t *testing.T) {
 
 	currentCmd := NewUseCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -71,7 +71,7 @@ func TestPipelineTemplateUse_missingFlags(t *testing.T) {
 	args := []string{"pipeline-template", "use"} // Missing id, application, name
 	currentCmd := NewUseCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 
@@ -99,7 +99,7 @@ func TestPipelineTemplateUse_templateVariables(t *testing.T) {
 
 	currentCmd := NewPlanCmd(pipelineTemplateOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineTemplateCmd := NewPipelineTemplateCmd(os.Stdout)
+	pipelineTemplateCmd := NewPipelineTemplateCmd()
 	pipelineTemplateCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineTemplateCmd)
 

--- a/cmd/pipeline/delete.go
+++ b/cmd/pipeline/delete.go
@@ -20,12 +20,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 )
 
-type DeleteOptions struct {
-	*pipelineOptions
+type deleteOptions struct {
+	*PipelineOptions
 	output      string
 	application string
 	name        string
@@ -36,9 +34,9 @@ var (
 	deletePipelineLong  = "Delete the provided pipeline"
 )
 
-func NewDeleteCmd(pipelineOptions pipelineOptions) *cobra.Command {
-	options := DeleteOptions{
-		pipelineOptions: &pipelineOptions,
+func NewDeleteCmd(pipelineOptions *PipelineOptions) *cobra.Command {
+	options := &deleteOptions{
+		PipelineOptions: pipelineOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "delete",
@@ -56,16 +54,11 @@ func NewDeleteCmd(pipelineOptions pipelineOptions) *cobra.Command {
 	return cmd
 }
 
-func deletePipeline(cmd *cobra.Command, options DeleteOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func deletePipeline(cmd *cobra.Command, options *deleteOptions) error {
 	if options.application == "" || options.name == "" {
 		return errors.New("one of required parameters 'application' or 'name' not set")
 	}
-	resp, err := gateClient.PipelineControllerApi.DeletePipelineUsingDELETE(gateClient.Context, options.application, options.name)
+	resp, err := options.GateClient.PipelineControllerApi.DeletePipelineUsingDELETE(options.GateClient.Context, options.application, options.name)
 
 	if err != nil {
 		return err
@@ -75,6 +68,6 @@ func deletePipeline(cmd *cobra.Command, options DeleteOptions) error {
 		return fmt.Errorf("Encountered an error deleting pipeline, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.Success("Pipeline deleted")
+	options.Ui.Success("Pipeline deleted")
 	return nil
 }

--- a/cmd/pipeline/delete.go
+++ b/cmd/pipeline/delete.go
@@ -75,6 +75,6 @@ func deletePipeline(cmd *cobra.Command, options DeleteOptions) error {
 		return fmt.Errorf("Encountered an error deleting pipeline, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Pipeline deleted")))
+	util.UI.Success("Pipeline deleted")
 	return nil
 }

--- a/cmd/pipeline/delete.go
+++ b/cmd/pipeline/delete.go
@@ -32,8 +32,8 @@ type DeleteOptions struct {
 }
 
 var (
-	deletePipelineShort   = "Delete the provided pipeline"
-	deletePipelineLong    = "Delete the provided pipeline"
+	deletePipelineShort = "Delete the provided pipeline"
+	deletePipelineLong  = "Delete the provided pipeline"
 )
 
 func NewDeleteCmd(pipelineOptions pipelineOptions) *cobra.Command {

--- a/cmd/pipeline/delete_test.go
+++ b/cmd/pipeline/delete_test.go
@@ -15,7 +15,6 @@
 package pipeline
 
 import (
-	"os"
 	"testing"
 
 	"github.com/spinnaker/spin/util"
@@ -30,7 +29,7 @@ func TestPipelineDelete_basic(t *testing.T) {
 	args := []string{"pipeline", "delete", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -48,7 +47,7 @@ func TestPipelineDelete_fail(t *testing.T) {
 	args := []string{"pipeline", "delete", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -66,7 +65,7 @@ func TestPipelineDelete_flags(t *testing.T) {
 	args := []string{"pipeline", "delete", "--gate-endpoint", ts.URL} // Missing pipeline app and name.
 	currentCmd := NewDeleteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -84,7 +83,7 @@ func TestPipelineDelete_missingname(t *testing.T) {
 	args := []string{"pipeline", "delete", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -102,7 +101,7 @@ func TestPipelineDelete_missingapp(t *testing.T) {
 	args := []string{"pipeline", "delete", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 

--- a/cmd/pipeline/delete_test.go
+++ b/cmd/pipeline/delete_test.go
@@ -17,6 +17,8 @@ package pipeline
 import (
 	"os"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 // TODO(jacobkiefer): This test overlaps heavily with pipeline_save_test.go,
@@ -27,13 +29,13 @@ func TestPipelineDelete_basic(t *testing.T) {
 
 	args := []string{"pipeline", "delete", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -45,13 +47,13 @@ func TestPipelineDelete_fail(t *testing.T) {
 
 	args := []string{"pipeline", "delete", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -63,13 +65,13 @@ func TestPipelineDelete_flags(t *testing.T) {
 
 	args := []string{"pipeline", "delete", "--gate-endpoint", ts.URL} // Missing pipeline app and name.
 	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -81,13 +83,13 @@ func TestPipelineDelete_missingname(t *testing.T) {
 
 	args := []string{"pipeline", "delete", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command errantly succeeded. %s", err)
 	}
@@ -99,13 +101,13 @@ func TestPipelineDelete_missingapp(t *testing.T) {
 
 	args := []string{"pipeline", "delete", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command errantly succeeded. %s", err)
 	}

--- a/cmd/pipeline/delete_test.go
+++ b/cmd/pipeline/delete_test.go
@@ -24,7 +24,7 @@ import (
 // TODO(jacobkiefer): This test overlaps heavily with pipeline_save_test.go,
 // consider factoring common testing code out.
 func TestPipelineDelete_basic(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -40,7 +40,7 @@ func TestPipelineDelete_basic(t *testing.T) {
 }
 
 func TestPipelineDelete_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -56,7 +56,7 @@ func TestPipelineDelete_fail(t *testing.T) {
 }
 
 func TestPipelineDelete_flags(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -72,7 +72,7 @@ func TestPipelineDelete_flags(t *testing.T) {
 }
 
 func TestPipelineDelete_missingname(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -88,7 +88,7 @@ func TestPipelineDelete_missingname(t *testing.T) {
 }
 
 func TestPipelineDelete_missingapp(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)

--- a/cmd/pipeline/delete_test.go
+++ b/cmd/pipeline/delete_test.go
@@ -15,9 +15,10 @@
 package pipeline
 
 import (
+	"io/ioutil"
 	"testing"
 
-	"github.com/spinnaker/spin/util"
+	"github.com/spinnaker/spin/cmd"
 )
 
 // TODO(jacobkiefer): This test overlaps heavily with pipeline_save_test.go,
@@ -26,15 +27,13 @@ func TestPipelineDelete_basic(t *testing.T) {
 	ts := GateServerSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "delete", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "delete", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -44,15 +43,13 @@ func TestPipelineDelete_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	args := []string{"pipeline", "delete", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "delete", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -62,15 +59,13 @@ func TestPipelineDelete_flags(t *testing.T) {
 	ts := GateServerSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "delete", "--gate-endpoint", ts.URL} // Missing pipeline app and name.
-	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "delete", "--gate-endpoint", ts.URL} // Missing pipeline app and name.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -80,15 +75,13 @@ func TestPipelineDelete_missingname(t *testing.T) {
 	ts := GateServerSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "delete", "--application", "app", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "delete", "--application", "app", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command errantly succeeded. %s", err)
 	}
@@ -98,15 +91,13 @@ func TestPipelineDelete_missingapp(t *testing.T) {
 	ts := GateServerSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "delete", "--name", "one", "--gate-endpoint", ts.URL}
-	currentCmd := NewDeleteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "delete", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command errantly succeeded. %s", err)
 	}

--- a/cmd/pipeline/execute.go
+++ b/cmd/pipeline/execute.go
@@ -20,12 +20,11 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
-type ExecuteOptions struct {
-	*pipelineOptions
+type executeOptions struct {
+	*PipelineOptions
 	output        string
 	application   string
 	name          string
@@ -38,9 +37,9 @@ var (
 	executePipelineLong  = "Execute the provided pipeline"
 )
 
-func NewExecuteCmd(pipelineOptions pipelineOptions) *cobra.Command {
-	options := ExecuteOptions{
-		pipelineOptions: &pipelineOptions,
+func NewExecuteCmd(pipelineOptions *PipelineOptions) *cobra.Command {
+	options := &executeOptions{
+		PipelineOptions: pipelineOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "execute",
@@ -60,18 +59,12 @@ func NewExecuteCmd(pipelineOptions pipelineOptions) *cobra.Command {
 	return cmd
 }
 
-func executePipeline(cmd *cobra.Command, options ExecuteOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func executePipeline(cmd *cobra.Command, options *executeOptions) error {
 	if options.application == "" || options.name == "" {
 		return errors.New("one of required parameters 'application' or 'name' not set")
 	}
 
-	parameters := map[string]interface{}{}
-	parameters, err = util.ParseJsonFromFile(options.parameterFile, true)
+	parameters, err := util.ParseJsonFromFile(options.parameterFile, true)
 	if err != nil {
 		return fmt.Errorf("Could not parse supplied pipeline parameters: %v.\n", err)
 	}
@@ -94,7 +87,7 @@ func executePipeline(cmd *cobra.Command, options ExecuteOptions) error {
 		}
 	}
 
-	resp, err := gateClient.PipelineControllerApi.InvokePipelineConfigUsingPOST1(gateClient.Context,
+	resp, err := options.GateClient.PipelineControllerApi.InvokePipelineConfigUsingPOST1(options.GateClient.Context,
 		options.application,
 		options.name,
 		map[string]interface{}{"trigger": trigger})
@@ -107,7 +100,7 @@ func executePipeline(cmd *cobra.Command, options ExecuteOptions) error {
 		return fmt.Errorf("Encountered an error executing pipeline, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.Success("Pipeline execution started")
+	options.Ui.Success("Pipeline execution started")
 
 	return nil
 }

--- a/cmd/pipeline/execute.go
+++ b/cmd/pipeline/execute.go
@@ -107,7 +107,7 @@ func executePipeline(cmd *cobra.Command, options ExecuteOptions) error {
 		return fmt.Errorf("Encountered an error executing pipeline, status code: %d\n", resp.StatusCode)
 	}
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Pipeline execution started")))
+	util.UI.Success("Pipeline execution started")
 
 	return nil
 }

--- a/cmd/pipeline/execute_test.go
+++ b/cmd/pipeline/execute_test.go
@@ -41,13 +41,13 @@ func TestPipelineExecute_basic(t *testing.T) {
 
 	args := []string{"pipeline", "execute", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,13 +65,13 @@ func TestPipelineExecute_fail(t *testing.T) {
 
 	args := []string{"pipeline", "execute", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -83,13 +83,13 @@ func TestPipelineExecute_flags(t *testing.T) {
 
 	args := []string{"pipeline", "execute", "--gate-endpoint", ts.URL} // Missing pipeline app and name.
 	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -107,13 +107,13 @@ func TestPipelineExecute_missingname(t *testing.T) {
 
 	args := []string{"pipeline", "execute", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -131,13 +131,13 @@ func TestPipelineExecute_missingapp(t *testing.T) {
 
 	args := []string{"pipeline", "execute", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/execute_test.go
+++ b/cmd/pipeline/execute_test.go
@@ -42,7 +42,7 @@ func TestPipelineExecute_basic(t *testing.T) {
 	args := []string{"pipeline", "execute", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewExecuteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -66,7 +66,7 @@ func TestPipelineExecute_fail(t *testing.T) {
 	args := []string{"pipeline", "execute", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewExecuteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -84,7 +84,7 @@ func TestPipelineExecute_flags(t *testing.T) {
 	args := []string{"pipeline", "execute", "--gate-endpoint", ts.URL} // Missing pipeline app and name.
 	currentCmd := NewExecuteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -108,7 +108,7 @@ func TestPipelineExecute_missingname(t *testing.T) {
 	args := []string{"pipeline", "execute", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewExecuteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -132,7 +132,7 @@ func TestPipelineExecute_missingapp(t *testing.T) {
 	args := []string{"pipeline", "execute", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewExecuteCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 

--- a/cmd/pipeline/execute_test.go
+++ b/cmd/pipeline/execute_test.go
@@ -54,7 +54,7 @@ func TestPipelineExecute_basic(t *testing.T) {
 }
 
 func TestPipelineExecute_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(testPipelineJsonStr)
@@ -76,7 +76,7 @@ func TestPipelineExecute_fail(t *testing.T) {
 }
 
 func TestPipelineExecute_flags(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -92,7 +92,7 @@ func TestPipelineExecute_flags(t *testing.T) {
 }
 
 func TestPipelineExecute_missingname(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(missingNameJsonStr)
@@ -114,7 +114,7 @@ func TestPipelineExecute_missingname(t *testing.T) {
 }
 
 func TestPipelineExecute_missingapp(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(missingAppJsonStr)

--- a/cmd/pipeline/execute_test.go
+++ b/cmd/pipeline/execute_test.go
@@ -17,12 +17,14 @@ package pipeline
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	gate "github.com/spinnaker/spin/gateapi"
 	"github.com/spinnaker/spin/util"
 )
@@ -39,15 +41,13 @@ func TestPipelineExecute_basic(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "execute", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
-	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "execute", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -63,15 +63,13 @@ func TestPipelineExecute_fail(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "execute", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
-	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "execute", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -81,15 +79,13 @@ func TestPipelineExecute_flags(t *testing.T) {
 	ts := GateServerSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "execute", "--gate-endpoint", ts.URL} // Missing pipeline app and name.
-	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "execute", "--gate-endpoint", ts.URL} // Missing pipeline app and name.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -105,15 +101,13 @@ func TestPipelineExecute_missingname(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "execute", "--application", "app", "--gate-endpoint", ts.URL}
-	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "execute", "--application", "app", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -129,15 +123,13 @@ func TestPipelineExecute_missingapp(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "execute", "--name", "one", "--gate-endpoint", ts.URL}
-	currentCmd := NewExecuteCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "execute", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/execution/cancel.go
+++ b/cmd/pipeline/execution/cancel.go
@@ -17,10 +17,11 @@ package execution
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
 )
 
 var (

--- a/cmd/pipeline/execution/cancel.go
+++ b/cmd/pipeline/execution/cancel.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -29,29 +28,33 @@ var (
 	cancelExecutionLong  = "Cancel the executions for the provided execution id"
 )
 
-func NewCancelCmd() *cobra.Command {
+type cancelOptions struct {
+	*executionOptions
+}
+
+func NewCancelCmd(executionOptions *executionOptions) *cobra.Command {
+	options := &cancelOptions{
+		executionOptions: executionOptions,
+	}
 	cmd := &cobra.Command{
 		Use:   "cancel",
 		Short: cancelExecutionShort,
 		Long:  cancelExecutionLong,
-		RunE:  cancelExecution,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cancelExecution(cmd, options, args)
+		},
 	}
 
 	return cmd
 }
 
-func cancelExecution(cmd *cobra.Command, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func cancelExecution(cmd *cobra.Command, options *cancelOptions, args []string) error {
 	executionId, err := util.ReadArgsOrStdin(args)
 	if executionId == "" {
 		return errors.New("no execution id supplied, exiting")
 	}
 
-	resp, err := gateClient.PipelineControllerApi.CancelPipelineUsingPUT1(gateClient.Context,
+	resp, err := options.GateClient.PipelineControllerApi.CancelPipelineUsingPUT1(options.GateClient.Context,
 		executionId,
 		map[string]interface{}{})
 
@@ -65,6 +68,6 @@ func cancelExecution(cmd *cobra.Command, args []string) error {
 			resp.StatusCode)
 	}
 
-	util.UI.Success(fmt.Sprintf("Execution %s successfully canceled", executionId))
+	options.Ui.Success(fmt.Sprintf("Execution %s successfully canceled", executionId))
 	return nil
 }

--- a/cmd/pipeline/execution/cancel.go
+++ b/cmd/pipeline/execution/cancel.go
@@ -65,6 +65,6 @@ func cancelExecution(cmd *cobra.Command, args []string) error {
 			resp.StatusCode)
 	}
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Execution %s successfully canceled", executionId)))
+	util.UI.Success(fmt.Sprintf("Execution %s successfully canceled", executionId))
 	return nil
 }

--- a/cmd/pipeline/execution/cancel_test.go
+++ b/cmd/pipeline/execution/cancel_test.go
@@ -22,13 +22,15 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spinnaker/spin/util"
 )
 
 func TestExecutionCancel_basic(t *testing.T) {
 	ts := testGateExecutionCancelSuccess()
 	defer ts.Close()
 	currentCmd := NewCancelCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
@@ -38,7 +40,7 @@ func TestExecutionCancel_basic(t *testing.T) {
 	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
 	args := []string{"ex", "cancel", "someId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -48,7 +50,7 @@ func TestExecutionCancel_noinput(t *testing.T) {
 	ts := testGateExecutionCancelSuccess()
 	defer ts.Close()
 	currentCmd := NewCancelCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
@@ -58,7 +60,7 @@ func TestExecutionCancel_noinput(t *testing.T) {
 	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
 	args := []string{"ex", "cancel", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %v", err)
 	}
@@ -68,7 +70,7 @@ func TestExecutionCancel_failure(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 	currentCmd := NewCancelCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
@@ -78,7 +80,7 @@ func TestExecutionCancel_failure(t *testing.T) {
 	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
 	args := []string{"ex", "cancel", "someId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %v", err)
 	}

--- a/cmd/pipeline/execution/cancel_test.go
+++ b/cmd/pipeline/execution/cancel_test.go
@@ -17,29 +17,28 @@ package execution
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/spinnaker/spin/util"
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/pipeline"
 )
 
 func TestExecutionCancel_basic(t *testing.T) {
 	ts := testGateExecutionCancelSuccess()
 	defer ts.Close()
-	currentCmd := NewCancelCmd()
-	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
-	rootCmd.AddCommand(executionCmd)
-
-	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
-	args := []string{"ex", "cancel", "someId", "--gate-endpoint", ts.URL}
+	args := []string{"pipeline", "ex", "cancel", "someId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -48,18 +47,16 @@ func TestExecutionCancel_basic(t *testing.T) {
 func TestExecutionCancel_noinput(t *testing.T) {
 	ts := testGateExecutionCancelSuccess()
 	defer ts.Close()
-	currentCmd := NewCancelCmd()
-	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
-
-	rootCmd.AddCommand(executionCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
 	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
-	args := []string{"ex", "cancel", "--gate-endpoint", ts.URL}
+	args := []string{"pipeline", "ex", "cancel", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %v", err)
 	}
@@ -68,18 +65,15 @@ func TestExecutionCancel_noinput(t *testing.T) {
 func TestExecutionCancel_failure(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
-	currentCmd := NewCancelCmd()
-	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
-	rootCmd.AddCommand(executionCmd)
-
-	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
-	args := []string{"ex", "cancel", "someId", "--gate-endpoint", ts.URL}
+	args := []string{"pipeline", "ex", "cancel", "someId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %v", err)
 	}

--- a/cmd/pipeline/execution/cancel_test.go
+++ b/cmd/pipeline/execution/cancel_test.go
@@ -63,7 +63,7 @@ func TestExecutionCancel_noinput(t *testing.T) {
 }
 
 func TestExecutionCancel_failure(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)

--- a/cmd/pipeline/execution/cancel_test.go
+++ b/cmd/pipeline/execution/cancel_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestExecutionCancel_basic(t *testing.T) {
 	currentCmd := NewCancelCmd()
 	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 
 	rootCmd.AddCommand(executionCmd)
@@ -52,7 +51,7 @@ func TestExecutionCancel_noinput(t *testing.T) {
 	currentCmd := NewCancelCmd()
 	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 
 	rootCmd.AddCommand(executionCmd)
@@ -72,7 +71,7 @@ func TestExecutionCancel_failure(t *testing.T) {
 	currentCmd := NewCancelCmd()
 	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 
 	rootCmd.AddCommand(executionCmd)

--- a/cmd/pipeline/execution/execution.go
+++ b/cmd/pipeline/execution/execution.go
@@ -15,8 +15,9 @@
 package execution
 
 import (
-	"github.com/spf13/cobra"
 	"io"
+
+	"github.com/spf13/cobra"
 )
 
 type executionOptions struct{}

--- a/cmd/pipeline/execution/execution.go
+++ b/cmd/pipeline/execution/execution.go
@@ -16,9 +16,12 @@ package execution
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd/pipeline"
 )
 
-type executionOptions struct{}
+type executionOptions struct {
+	*pipeline.PipelineOptions
+}
 
 var (
 	executionShort   = ""
@@ -26,8 +29,10 @@ var (
 	executionExample = ""
 )
 
-func NewExecutionCmd() *cobra.Command {
-	options := executionOptions{}
+func NewExecutionCmd(pipelineOptions *pipeline.PipelineOptions) *cobra.Command {
+	options := &executionOptions{
+		PipelineOptions: pipelineOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "execution",
 		Aliases: []string{"executions", "ex"},
@@ -37,8 +42,8 @@ func NewExecutionCmd() *cobra.Command {
 	}
 
 	// create subcommands
-	cmd.AddCommand(NewCancelCmd())
-	cmd.AddCommand(NewGetCmd())
+	cmd.AddCommand(NewCancelCmd(options))
+	cmd.AddCommand(NewGetCmd(options))
 	cmd.AddCommand(NewListCmd(options))
 	return cmd
 }

--- a/cmd/pipeline/execution/execution.go
+++ b/cmd/pipeline/execution/execution.go
@@ -15,8 +15,6 @@
 package execution
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +26,7 @@ var (
 	executionExample = ""
 )
 
-func NewExecutionCmd(out io.Writer) *cobra.Command {
+func NewExecutionCmd() *cobra.Command {
 	options := executionOptions{}
 	cmd := &cobra.Command{
 		Use:     "execution",

--- a/cmd/pipeline/execution/get.go
+++ b/cmd/pipeline/execution/get.go
@@ -67,6 +67,6 @@ func getExecution(cmd *cobra.Command, args []string) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline/execution/get.go
+++ b/cmd/pipeline/execution/get.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,22 +27,26 @@ var (
 	getExecutionLong  = "Get the execution with the provided id "
 )
 
-func NewGetCmd() *cobra.Command {
+type getOptions struct {
+	*executionOptions
+}
+
+func NewGetCmd(executionOptions *executionOptions) *cobra.Command {
+	options := &getOptions{
+		executionOptions: executionOptions,
+	}
 	cmd := &cobra.Command{
 		Use:   "get",
 		Short: getExecutionShort,
 		Long:  getExecutionLong,
-		RunE:  getExecution,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getExecution(cmd, options, args)
+		},
 	}
 	return cmd
 }
 
-func getExecution(cmd *cobra.Command, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func getExecution(cmd *cobra.Command, options *getOptions, args []string) error {
 	id, err := util.ReadArgsOrStdin(args)
 	if err != nil {
 		return err
@@ -54,8 +57,8 @@ func getExecution(cmd *cobra.Command, args []string) error {
 		"limit":        int32(1),
 	}
 
-	successPayload, resp, err := gateClient.ExecutionsControllerApi.GetLatestExecutionsByConfigIdsUsingGET(
-		gateClient.Context, query)
+	successPayload, resp, err := options.GateClient.ExecutionsControllerApi.GetLatestExecutionsByConfigIdsUsingGET(
+		options.GateClient.Context, query)
 
 	if err != nil {
 		return err
@@ -67,6 +70,6 @@ func getExecution(cmd *cobra.Command, args []string) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline/execution/get_test.go
+++ b/cmd/pipeline/execution/get_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestExecutionGet_basic(t *testing.T) {
 	currentCmd := NewGetCmd()
 	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 
 	rootCmd.AddCommand(executionCmd)
@@ -51,7 +50,7 @@ func TestExecutionGet_noinput(t *testing.T) {
 	currentCmd := NewGetCmd()
 	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 
 	rootCmd.AddCommand(executionCmd)
@@ -71,7 +70,7 @@ func TestExecutionGet_failure(t *testing.T) {
 	currentCmd := NewGetCmd()
 	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 
 	rootCmd.AddCommand(executionCmd)

--- a/cmd/pipeline/execution/get_test.go
+++ b/cmd/pipeline/execution/get_test.go
@@ -62,7 +62,7 @@ func TestExecutionGet_noinput(t *testing.T) {
 }
 
 func TestExecutionGet_failure(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -88,9 +88,9 @@ func testGateExecutionGetSuccess() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// GateServerFail spins up a local http server that we will configure the GateClient
+// testGateFail spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 500 InternalServerError.
-func GateServerFail() *httptest.Server {
+func testGateFail() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/executions/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// TODO(jacobkiefer): Mock more robust errors once implemented upstream.

--- a/cmd/pipeline/execution/get_test.go
+++ b/cmd/pipeline/execution/get_test.go
@@ -16,33 +16,20 @@ package execution
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/util"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
-)
 
-func getRootCmdForTest() *cobra.Command {
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
-	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
-	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
-	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
-	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
-	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
-	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
-	util.InitUI(false, false, "")
-	return rootCmd
-}
+	"github.com/spinnaker/spin/util"
+)
 
 func TestExecutionGet_basic(t *testing.T) {
 	ts := testGateExecutionGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
@@ -52,7 +39,7 @@ func TestExecutionGet_basic(t *testing.T) {
 	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
 	args := []string{"ex", "get", "someId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -62,7 +49,7 @@ func TestExecutionGet_noinput(t *testing.T) {
 	ts := testGateExecutionGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
@@ -72,7 +59,7 @@ func TestExecutionGet_noinput(t *testing.T) {
 	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
 	args := []string{"ex", "get", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -82,7 +69,7 @@ func TestExecutionGet_failure(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 	currentCmd := NewGetCmd()
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
@@ -92,7 +79,7 @@ func TestExecutionGet_failure(t *testing.T) {
 	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
 	args := []string{"ex", "get", "someId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/execution/get_test.go
+++ b/cmd/pipeline/execution/get_test.go
@@ -16,29 +16,29 @@ package execution
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/pipeline"
 	"github.com/spinnaker/spin/util"
 )
 
 func TestExecutionGet_basic(t *testing.T) {
 	ts := testGateExecutionGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd()
-	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
-	rootCmd.AddCommand(executionCmd)
-
-	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
-	args := []string{"ex", "get", "someId", "--gate-endpoint", ts.URL}
+	args := []string{"pipeline", "ex", "get", "someId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -47,18 +47,15 @@ func TestExecutionGet_basic(t *testing.T) {
 func TestExecutionGet_noinput(t *testing.T) {
 	ts := testGateExecutionGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd()
-	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
-	rootCmd.AddCommand(executionCmd)
-
-	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
-	args := []string{"ex", "get", "--gate-endpoint", ts.URL}
+	args := []string{"pipeline", "ex", "get", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -67,18 +64,15 @@ func TestExecutionGet_noinput(t *testing.T) {
 func TestExecutionGet_failure(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
-	currentCmd := NewGetCmd()
-	rootCmd := util.NewRootCmdForTest()
 
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
-	rootCmd.AddCommand(executionCmd)
-
-	// Exclude 'pipeline' since we are testing only the 'execution' subcommand.
-	args := []string{"ex", "get", "someId", "--gate-endpoint", ts.URL}
+	args := []string{"pipeline", "ex", "get", "someId", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/execution/list.go
+++ b/cmd/pipeline/execution/list.go
@@ -113,6 +113,6 @@ func listExecution(cmd *cobra.Command, options ListOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline/execution/list.go
+++ b/cmd/pipeline/execution/list.go
@@ -21,11 +21,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 )
 
-type ListOptions struct {
+type listOptions struct {
 	*executionOptions
 	output           string
 	pipelineConfigId string
@@ -41,9 +39,9 @@ var (
 	listExecutionLong  = "List the executions for the provided pipeline id"
 )
 
-func NewListCmd(executionOptions executionOptions) *cobra.Command {
-	options := ListOptions{
-		executionOptions: &executionOptions,
+func NewListCmd(executionOptions *executionOptions) *cobra.Command {
+	options := &listOptions{
+		executionOptions: executionOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -65,12 +63,7 @@ func NewListCmd(executionOptions executionOptions) *cobra.Command {
 	return cmd
 }
 
-func listExecution(cmd *cobra.Command, options ListOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func listExecution(cmd *cobra.Command, options *listOptions) error {
 	if options.pipelineConfigId == "" {
 		return errors.New("required parameter 'pipeline-id' not set")
 	}
@@ -100,8 +93,8 @@ func listExecution(cmd *cobra.Command, options ListOptions) error {
 		query["limit"] = options.limit
 	}
 
-	successPayload, resp, err := gateClient.ExecutionsControllerApi.GetLatestExecutionsByConfigIdsUsingGET(
-		gateClient.Context, query)
+	successPayload, resp, err := options.GateClient.ExecutionsControllerApi.GetLatestExecutionsByConfigIdsUsingGET(
+		options.GateClient.Context, query)
 
 	if err != nil {
 		return err
@@ -113,6 +106,6 @@ func listExecution(cmd *cobra.Command, options ListOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline/execution/list.go
+++ b/cmd/pipeline/execution/list.go
@@ -17,11 +17,12 @@ package execution
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/util"
-	"net/http"
-	"strings"
 )
 
 type ListOptions struct {

--- a/cmd/pipeline/execution/list_test.go
+++ b/cmd/pipeline/execution/list_test.go
@@ -16,11 +16,14 @@ package execution
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/cmd/pipeline"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,15 +31,14 @@ func TestExecutionList_basic(t *testing.T) {
 	ts := testGateExecutionListSuccess()
 	defer ts.Close()
 
-	args := []string{"execution", "list", "--pipeline-id", "myid", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(executionOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(executionCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "execution", "list", "--pipeline-id", "myid", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -47,15 +49,14 @@ func TestExecutionList_flags(t *testing.T) {
 	ts := testGateExecutionListSuccess()
 	defer ts.Close()
 
-	args := []string{"execution", "list", "--gate-endpoint", ts.URL} // Missing pipeline id.
-	currentCmd := NewListCmd(executionOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(executionCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "execution", "list", "--gate-endpoint", ts.URL} // Missing pipeline id.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,15 +66,14 @@ func TestExecutionList_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	args := []string{"execution", "list", "--pipeline-id", "myid", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(executionOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	executionCmd := NewExecutionCmd()
-	executionCmd.AddCommand(currentCmd)
-	rootCmd.AddCommand(executionCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, pipelineOpts := pipeline.NewPipelineCmd(rootOpts)
+	pipelineCmd.AddCommand(NewExecutionCmd(pipelineOpts))
+	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "execution", "list", "--pipeline-id", "myid", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/execution/list_test.go
+++ b/cmd/pipeline/execution/list_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestExecutionList_basic(t *testing.T) {
 	args := []string{"execution", "list", "--pipeline-id", "myid", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(executionOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(executionCmd)
 
@@ -51,7 +50,7 @@ func TestExecutionList_flags(t *testing.T) {
 	args := []string{"execution", "list", "--gate-endpoint", ts.URL} // Missing pipeline id.
 	currentCmd := NewListCmd(executionOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(executionCmd)
 
@@ -69,7 +68,7 @@ func TestExecutionList_fail(t *testing.T) {
 	args := []string{"execution", "list", "--pipeline-id", "myid", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(executionOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	executionCmd := NewExecutionCmd(os.Stdout)
+	executionCmd := NewExecutionCmd()
 	executionCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(executionCmd)
 

--- a/cmd/pipeline/execution/list_test.go
+++ b/cmd/pipeline/execution/list_test.go
@@ -31,13 +31,13 @@ func TestExecutionList_basic(t *testing.T) {
 
 	args := []string{"execution", "list", "--pipeline-id", "myid", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(executionOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(executionCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -50,13 +50,13 @@ func TestExecutionList_flags(t *testing.T) {
 
 	args := []string{"execution", "list", "--gate-endpoint", ts.URL} // Missing pipeline id.
 	currentCmd := NewListCmd(executionOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(executionCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -68,13 +68,13 @@ func TestExecutionList_fail(t *testing.T) {
 
 	args := []string{"execution", "list", "--pipeline-id", "myid", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(executionOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	executionCmd := NewExecutionCmd(os.Stdout)
 	executionCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(executionCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/execution/list_test.go
+++ b/cmd/pipeline/execution/list_test.go
@@ -63,7 +63,7 @@ func TestExecutionList_flags(t *testing.T) {
 }
 
 func TestExecutionList_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)

--- a/cmd/pipeline/get.go
+++ b/cmd/pipeline/get.go
@@ -80,6 +80,6 @@ func getPipeline(cmd *cobra.Command, options GetOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline/get.go
+++ b/cmd/pipeline/get.go
@@ -32,8 +32,8 @@ type GetOptions struct {
 }
 
 var (
-	getPipelineShort   = "Get the pipeline with the provided name from the provided application"
-	getPipelineLong    = "Get the specified pipeline"
+	getPipelineShort = "Get the pipeline with the provided name from the provided application"
+	getPipelineLong  = "Get the specified pipeline"
 )
 
 func NewGetCmd(pipelineOptions pipelineOptions) *cobra.Command {
@@ -41,9 +41,9 @@ func NewGetCmd(pipelineOptions pipelineOptions) *cobra.Command {
 		pipelineOptions: &pipelineOptions,
 	}
 	cmd := &cobra.Command{
-		Use:     "get",
-		Short:   getPipelineShort,
-		Long:    getPipelineLong,
+		Use:   "get",
+		Short: getPipelineShort,
+		Long:  getPipelineLong,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return getPipeline(cmd, options)
 		},

--- a/cmd/pipeline/get.go
+++ b/cmd/pipeline/get.go
@@ -20,12 +20,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 )
 
-type GetOptions struct {
-	*pipelineOptions
+type getOptions struct {
+	*PipelineOptions
 	output      string
 	application string
 	name        string
@@ -36,9 +34,9 @@ var (
 	getPipelineLong  = "Get the specified pipeline"
 )
 
-func NewGetCmd(pipelineOptions pipelineOptions) *cobra.Command {
-	options := GetOptions{
-		pipelineOptions: &pipelineOptions,
+func NewGetCmd(pipelineOptions *PipelineOptions) *cobra.Command {
+	options := &getOptions{
+		PipelineOptions: pipelineOptions,
 	}
 	cmd := &cobra.Command{
 		Use:   "get",
@@ -55,17 +53,12 @@ func NewGetCmd(pipelineOptions pipelineOptions) *cobra.Command {
 	return cmd
 }
 
-func getPipeline(cmd *cobra.Command, options GetOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func getPipeline(cmd *cobra.Command, options *getOptions) error {
 	if options.application == "" || options.name == "" {
 		return errors.New("one of required parameters 'application' or 'name' not set")
 	}
 
-	successPayload, resp, err := gateClient.ApplicationControllerApi.GetPipelineConfigUsingGET(gateClient.Context,
+	successPayload, resp, err := options.GateClient.ApplicationControllerApi.GetPipelineConfigUsingGET(options.GateClient.Context,
 		options.application,
 		options.name)
 
@@ -80,6 +73,6 @@ func getPipeline(cmd *cobra.Command, options GetOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline/get_test.go
+++ b/cmd/pipeline/get_test.go
@@ -15,6 +15,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -22,15 +23,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/andreyvit/diff"
 	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
-func TestPipelineGet_basic(t *testing.T) {
+func TestPipelineGet_json(t *testing.T) {
 	ts := testGatePipelineGetSuccess()
 	defer ts.Close()
 
-	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	buffer := new(bytes.Buffer)
+	rootCmd, rootOpts := cmd.NewCmdRoot(buffer, buffer)
 	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -39,6 +42,35 @@ func TestPipelineGet_basic(t *testing.T) {
 	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(pipelineGetJson)
+	recieved := strings.TrimSpace(buffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected command output:\n%s", diff.LineDiff(expected, recieved))
+	}
+}
+
+func TestPipelineGet_yaml(t *testing.T) {
+	ts := testGatePipelineGetSuccess()
+	defer ts.Close()
+
+	buffer := new(bytes.Buffer)
+	rootCmd, rootOpts := cmd.NewCmdRoot(buffer, buffer)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
+	rootCmd.AddCommand(pipelineCmd)
+
+	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--output", "yaml", "--gate-endpoint", ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(pipelineGetYaml)
+	recieved := strings.TrimSpace(buffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected command output:\n%s", diff.LineDiff(expected, recieved))
 	}
 }
 
@@ -56,7 +88,6 @@ func TestPipelineGet_flags(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
-
 }
 
 func TestPipelineGet_malformed(t *testing.T) {
@@ -73,11 +104,10 @@ func TestPipelineGet_malformed(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
-
 }
 
 func TestPipelineGet_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -112,7 +142,7 @@ func TestPipelineGet_notfound(t *testing.T) {
 // to direct requests to. Responds with a 200 and a well-formed pipeline get response.
 func testGatePipelineGetSuccess() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
-	mux.Handle("/applications/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("/applications/app/pipelineConfigs/one", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, strings.TrimSpace(pipelineGetJson))
 	}))
 	return httptest.NewServer(mux)
@@ -121,7 +151,7 @@ func testGatePipelineGetSuccess() *httptest.Server {
 // testGatePipelineGetMalformed returns a malformed get response of pipeline configs.
 func testGatePipelineGetMalformed() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
-	mux.Handle("/applications/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("/applications/app/pipelineConfigs/one", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, strings.TrimSpace(malformedPipelineGetJson))
 	}))
 	return httptest.NewServer(mux)
@@ -130,7 +160,7 @@ func testGatePipelineGetMalformed() *httptest.Server {
 // testGatePipelineGetMissing returns a 404 Not Found for an errant pipeline name|application pair.
 func testGatePipelineGetMissing() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
-	mux.Handle("/applications/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("/applications/app/pipelineConfigs/two", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
 	return httptest.NewServer(mux)
@@ -169,32 +199,56 @@ const malformedPipelineGetJson = `
 
 const pipelineGetJson = `
 {
-  "application": "app",
-  "id": "pipeline_one",
-  "index": 0,
-  "keepWaitingPipelines": false,
-  "lastModifiedBy": "jacobkiefer@google.com",
-  "limitConcurrent": true,
-  "name": "one",
-  "parameterConfig": [
-    {
-      "default": "blah",
-      "description": "A foo.",
-      "name": "foooB",
-      "required": true
-    }
-  ],
-  "stages": [
-    {
-      "comments": "${ parameters.derp }",
-      "name": "Wait",
-      "refId": "1",
-      "requisiteStageRefIds": [],
-      "type": "wait",
-      "waitTime": 30
-    }
-  ],
-  "triggers": [],
-  "updateTs": "1526578883109"
+ "application": "app",
+ "id": "pipeline_one",
+ "index": 0,
+ "keepWaitingPipelines": false,
+ "lastModifiedBy": "jacobkiefer@google.com",
+ "limitConcurrent": true,
+ "name": "one",
+ "parameterConfig": [
+  {
+   "default": "blah",
+   "description": "A foo.",
+   "name": "foooB",
+   "required": true
+  }
+ ],
+ "stages": [
+  {
+   "comments": "${ parameters.derp }",
+   "name": "Wait",
+   "refId": "1",
+   "requisiteStageRefIds": [],
+   "type": "wait",
+   "waitTime": 30
+  }
+ ],
+ "triggers": [],
+ "updateTs": "1526578883109"
 }
+`
+
+const pipelineGetYaml = `
+application: app
+id: pipeline_one
+index: 0
+keepWaitingPipelines: false
+lastModifiedBy: jacobkiefer@google.com
+limitConcurrent: true
+name: one
+parameterConfig:
+- default: blah
+  description: A foo.
+  name: foooB
+  required: true
+stages:
+- comments: ${ parameters.derp }
+  name: Wait
+  refId: "1"
+  requisiteStageRefIds: []
+  type: wait
+  waitTime: 30
+triggers: []
+updateTs: "1526578883109"
 `

--- a/cmd/pipeline/get_test.go
+++ b/cmd/pipeline/get_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestPipelineGet_basic(t *testing.T) {
 	defer ts.Close()
 	currentCmd := NewGetCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -49,7 +48,7 @@ func TestPipelineGet_flags(t *testing.T) {
 	args := []string{"pipeline", "get", "--gate-endpoint", ts.URL} // Missing application and name.
 	currentCmd := NewGetCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -68,7 +67,7 @@ func TestPipelineGet_malformed(t *testing.T) {
 	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -87,7 +86,7 @@ func TestPipelineGet_fail(t *testing.T) {
 	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -105,7 +104,7 @@ func TestPipelineGet_notfound(t *testing.T) {
 	args := []string{"pipeline", "get", "--application", "app", "--name", "two", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 

--- a/cmd/pipeline/get_test.go
+++ b/cmd/pipeline/get_test.go
@@ -22,35 +22,21 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/util"
 )
-
-func getRootCmdForTest() *cobra.Command {
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
-	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
-	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
-	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
-	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
-	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
-	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
-	util.InitUI(false, false, "")
-	return rootCmd
-}
 
 func TestPipelineGet_basic(t *testing.T) {
 	ts := testGatePipelineGetSuccess()
 	defer ts.Close()
 	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -62,13 +48,13 @@ func TestPipelineGet_flags(t *testing.T) {
 
 	args := []string{"pipeline", "get", "--gate-endpoint", ts.URL} // Missing application and name.
 	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -81,13 +67,13 @@ func TestPipelineGet_malformed(t *testing.T) {
 
 	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -100,13 +86,13 @@ func TestPipelineGet_fail(t *testing.T) {
 
 	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -118,13 +104,13 @@ func TestPipelineGet_notfound(t *testing.T) {
 
 	args := []string{"pipeline", "get", "--application", "app", "--name", "two", "--gate-endpoint", ts.URL}
 	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/get_test.go
+++ b/cmd/pipeline/get_test.go
@@ -16,26 +16,27 @@ package pipeline
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
 func TestPipelineGet_basic(t *testing.T) {
 	ts := testGatePipelineGetSuccess()
 	defer ts.Close()
-	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
 	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -45,15 +46,13 @@ func TestPipelineGet_flags(t *testing.T) {
 	ts := testGatePipelineGetSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "get", "--gate-endpoint", ts.URL} // Missing application and name.
-	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "get", "--gate-endpoint", ts.URL} // Missing application and name.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -64,15 +63,13 @@ func TestPipelineGet_malformed(t *testing.T) {
 	ts := testGatePipelineGetMalformed()
 	defer ts.Close()
 
-	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
-	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -83,15 +80,13 @@ func TestPipelineGet_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
-	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "get", "--application", "app", "--name", "one", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -101,15 +96,13 @@ func TestPipelineGet_notfound(t *testing.T) {
 	ts := testGatePipelineGetMissing()
 	defer ts.Close()
 
-	args := []string{"pipeline", "get", "--application", "app", "--name", "two", "--gate-endpoint", ts.URL}
-	currentCmd := NewGetCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "get", "--application", "app", "--name", "two", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -20,12 +20,10 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
-	"github.com/spinnaker/spin/util"
 )
 
-type ListOptions struct {
-	*pipelineOptions
+type listOptions struct {
+	*PipelineOptions
 	output      string
 	application string
 }
@@ -35,9 +33,9 @@ var (
 	listPipelineLong  = "List the pipelines for the provided application"
 )
 
-func NewListCmd(pipelineOptions pipelineOptions) *cobra.Command {
-	options := ListOptions{
-		pipelineOptions: &pipelineOptions,
+func NewListCmd(pipelineOptions *PipelineOptions) *cobra.Command {
+	options := &listOptions{
+		PipelineOptions: pipelineOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -54,17 +52,12 @@ func NewListCmd(pipelineOptions pipelineOptions) *cobra.Command {
 	return cmd
 }
 
-func listPipeline(cmd *cobra.Command, options ListOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func listPipeline(cmd *cobra.Command, options *listOptions) error {
 	if options.application == "" {
 		return errors.New("required parameter 'application' not set")
 	}
 
-	successPayload, resp, err := gateClient.ApplicationControllerApi.GetPipelineConfigsForApplicationUsingGET(gateClient.Context, options.application)
+	successPayload, resp, err := options.GateClient.ApplicationControllerApi.GetPipelineConfigsForApplicationUsingGET(options.GateClient.Context, options.application)
 
 	if err != nil {
 		return err
@@ -76,6 +69,6 @@ func listPipeline(cmd *cobra.Command, options ListOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload)
+	options.Ui.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -31,8 +31,8 @@ type ListOptions struct {
 }
 
 var (
-	listPipelineShort   = "List the pipelines for the provided application"
-	listPipelineLong    = "List the pipelines for the provided application"
+	listPipelineShort = "List the pipelines for the provided application"
+	listPipelineLong  = "List the pipelines for the provided application"
 )
 
 func NewListCmd(pipelineOptions pipelineOptions) *cobra.Command {

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -76,6 +76,6 @@ func listPipeline(cmd *cobra.Command, options ListOptions) error {
 			resp.StatusCode)
 	}
 
-	util.UI.JsonOutput(successPayload, util.UI.OutputFormat)
+	util.UI.JsonOutput(successPayload)
 	return nil
 }

--- a/cmd/pipeline/list_test.go
+++ b/cmd/pipeline/list_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestPipelineList_basic(t *testing.T) {
 	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -51,7 +50,7 @@ func TestPipelineList_flags(t *testing.T) {
 	args := []string{"pipeline", "list", "--gate-endpoint", ts.URL} // Missing application.
 	currentCmd := NewListCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -69,7 +68,7 @@ func TestPipelineList_malformed(t *testing.T) {
 	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -87,7 +86,7 @@ func TestPipelineList_fail(t *testing.T) {
 	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 

--- a/cmd/pipeline/list_test.go
+++ b/cmd/pipeline/list_test.go
@@ -16,11 +16,13 @@ package pipeline
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -28,34 +30,29 @@ func TestPipelineList_basic(t *testing.T) {
 	ts := testGatePipelineListSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
-
 }
 
 func TestPipelineList_flags(t *testing.T) {
 	ts := testGatePipelineListSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "list", "--gate-endpoint", ts.URL} // Missing application.
-	currentCmd := NewListCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "list", "--gate-endpoint", ts.URL} // Missing application.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,15 +62,13 @@ func TestPipelineList_malformed(t *testing.T) {
 	ts := testGatePipelineListMalformed()
 	defer ts.Close()
 
-	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -83,15 +78,13 @@ func TestPipelineList_fail(t *testing.T) {
 	ts := GateServerFail()
 	defer ts.Close()
 
-	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
-	currentCmd := NewListCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/list_test.go
+++ b/cmd/pipeline/list_test.go
@@ -75,7 +75,7 @@ func TestPipelineList_malformed(t *testing.T) {
 }
 
 func TestPipelineList_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)

--- a/cmd/pipeline/list_test.go
+++ b/cmd/pipeline/list_test.go
@@ -31,13 +31,13 @@ func TestPipelineList_basic(t *testing.T) {
 
 	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -50,13 +50,13 @@ func TestPipelineList_flags(t *testing.T) {
 
 	args := []string{"pipeline", "list", "--gate-endpoint", ts.URL} // Missing application.
 	currentCmd := NewListCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -68,13 +68,13 @@ func TestPipelineList_malformed(t *testing.T) {
 
 	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -86,13 +86,13 @@ func TestPipelineList_fail(t *testing.T) {
 
 	args := []string{"pipeline", "list", "--application", "app", "--gate-endpoint", ts.URL}
 	currentCmd := NewListCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -1,9 +1,10 @@
 package pipeline
 
 import (
+	"io"
+
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/pipeline/execution"
-	"io"
 )
 
 type pipelineOptions struct{}

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -1,8 +1,6 @@
 package pipeline
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/pipeline/execution"
 )
@@ -15,7 +13,7 @@ var (
 	pipelineExample = ""
 )
 
-func NewPipelineCmd(out io.Writer) *cobra.Command {
+func NewPipelineCmd() *cobra.Command {
 	options := pipelineOptions{}
 	cmd := &cobra.Command{
 		Use:     "pipeline",
@@ -31,6 +29,6 @@ func NewPipelineCmd(out io.Writer) *cobra.Command {
 	cmd.AddCommand(NewDeleteCmd(options))
 	cmd.AddCommand(NewSaveCmd(options))
 	cmd.AddCommand(NewExecuteCmd(options))
-	cmd.AddCommand(execution.NewExecutionCmd(out))
+	cmd.AddCommand(execution.NewExecutionCmd())
 	return cmd
 }

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -2,10 +2,12 @@ package pipeline
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/pipeline/execution"
+	"github.com/spinnaker/spin/cmd"
 )
 
-type pipelineOptions struct{}
+type PipelineOptions struct {
+	*cmd.RootOptions
+}
 
 var (
 	pipelineShort   = ""
@@ -13,8 +15,10 @@ var (
 	pipelineExample = ""
 )
 
-func NewPipelineCmd() *cobra.Command {
-	options := pipelineOptions{}
+func NewPipelineCmd(rootOptions *cmd.RootOptions) (*cobra.Command, *PipelineOptions) {
+	options := &PipelineOptions{
+		RootOptions: rootOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "pipeline",
 		Aliases: []string{"pipelines", "pi"},
@@ -29,6 +33,5 @@ func NewPipelineCmd() *cobra.Command {
 	cmd.AddCommand(NewDeleteCmd(options))
 	cmd.AddCommand(NewSaveCmd(options))
 	cmd.AddCommand(NewExecuteCmd(options))
-	cmd.AddCommand(execution.NewExecutionCmd())
-	return cmd
+	return cmd, options
 }

--- a/cmd/pipeline/save.go
+++ b/cmd/pipeline/save.go
@@ -80,7 +80,7 @@ func savePipeline(cmd *cobra.Command, options SaveOptions) error {
 			util.UI.Error("Required pipeline key 'schema' missing for templated pipeline...\n")
 			valid = false
 		}
-	    pipelineJson["type"] = "templatedPipeline"
+		pipelineJson["type"] = "templatedPipeline"
 	}
 
 	if !valid {

--- a/cmd/pipeline/save.go
+++ b/cmd/pipeline/save.go
@@ -19,13 +19,12 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 
 	"github.com/spinnaker/spin/util"
 )
 
-type SaveOptions struct {
-	*pipelineOptions
+type saveOptions struct {
+	*PipelineOptions
 	output       string
 	pipelineFile string
 }
@@ -35,9 +34,9 @@ var (
 	savePipelineLong  = "Save the provided pipeline"
 )
 
-func NewSaveCmd(pipelineOptions pipelineOptions) *cobra.Command {
-	options := SaveOptions{
-		pipelineOptions: &pipelineOptions,
+func NewSaveCmd(pipelineOptions *PipelineOptions) *cobra.Command {
+	options := &saveOptions{
+		PipelineOptions: pipelineOptions,
 	}
 	cmd := &cobra.Command{
 		Use:     "save",
@@ -54,30 +53,25 @@ func NewSaveCmd(pipelineOptions pipelineOptions) *cobra.Command {
 	return cmd
 }
 
-func savePipeline(cmd *cobra.Command, options SaveOptions) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func savePipeline(cmd *cobra.Command, options *saveOptions) error {
 	pipelineJson, err := util.ParseJsonFromFileOrStdin(options.pipelineFile, false)
 	if err != nil {
 		return err
 	}
 	valid := true
 	if _, exists := pipelineJson["name"]; !exists {
-		util.UI.Error("Required pipeline key 'name' missing...\n")
+		options.Ui.Error("Required pipeline key 'name' missing...\n")
 		valid = false
 	}
 
 	if _, exists := pipelineJson["application"]; !exists {
-		util.UI.Error("Required pipeline key 'application' missing...\n")
+		options.Ui.Error("Required pipeline key 'application' missing...\n")
 		valid = false
 	}
 
 	if template, exists := pipelineJson["template"]; exists && len(template.(map[string]interface{})) > 0 {
 		if _, exists := pipelineJson["schema"]; !exists {
-			util.UI.Error("Required pipeline key 'schema' missing for templated pipeline...\n")
+			options.Ui.Error("Required pipeline key 'schema' missing for templated pipeline...\n")
 			valid = false
 		}
 		pipelineJson["type"] = "templatedPipeline"
@@ -89,7 +83,7 @@ func savePipeline(cmd *cobra.Command, options SaveOptions) error {
 	application := pipelineJson["application"].(string)
 	pipelineName := pipelineJson["name"].(string)
 
-	foundPipeline, queryResp, _ := gateClient.ApplicationControllerApi.GetPipelineConfigUsingGET(gateClient.Context, application, pipelineName)
+	foundPipeline, queryResp, _ := options.GateClient.ApplicationControllerApi.GetPipelineConfigUsingGET(options.GateClient.Context, application, pipelineName)
 
 	if queryResp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Encountered an error querying pipeline, status code: %d\n", queryResp.StatusCode)
@@ -104,7 +98,7 @@ func savePipeline(cmd *cobra.Command, options SaveOptions) error {
 		pipelineJson["id"] = foundPipelineId
 	}
 
-	saveResp, saveErr := gateClient.PipelineControllerApi.SavePipelineUsingPOST(gateClient.Context, pipelineJson)
+	saveResp, saveErr := options.GateClient.PipelineControllerApi.SavePipelineUsingPOST(options.GateClient.Context, pipelineJson)
 
 	if saveErr != nil {
 		return saveErr
@@ -113,6 +107,6 @@ func savePipeline(cmd *cobra.Command, options SaveOptions) error {
 		return fmt.Errorf("Encountered an error saving pipeline, status code: %d\n", saveResp.StatusCode)
 	}
 
-	util.UI.Success("Pipeline save succeeded")
+	options.Ui.Success("Pipeline save succeeded")
 	return nil
 }

--- a/cmd/pipeline/save.go
+++ b/cmd/pipeline/save.go
@@ -113,6 +113,6 @@ func savePipeline(cmd *cobra.Command, options SaveOptions) error {
 		return fmt.Errorf("Encountered an error saving pipeline, status code: %d\n", saveResp.StatusCode)
 	}
 
-	util.UI.Info(util.Colorize().Color(fmt.Sprintf("[reset][bold][green]Pipeline save succeeded")))
+	util.UI.Success("Pipeline save succeeded")
 	return nil
 }

--- a/cmd/pipeline/save_test.go
+++ b/cmd/pipeline/save_test.go
@@ -37,13 +37,13 @@ func TestPipelineSave_basic(t *testing.T) {
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
 	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -67,13 +67,13 @@ func TestPipelineSave_stdin(t *testing.T) {
 
 	args := []string{"pipeline", "save", "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -91,13 +91,13 @@ func TestPipelineSave_fail(t *testing.T) {
 
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -115,13 +115,13 @@ func TestPipelineSave_accessdenied(t *testing.T) {
 
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -132,13 +132,13 @@ func TestPipelineSave_flags(t *testing.T) {
 
 	args := []string{"pipeline", "save", "--gate-endpoint", ts.URL} // Missing pipeline spec file.
 	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -156,13 +156,13 @@ func TestPipelineSave_missingname(t *testing.T) {
 
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -180,13 +180,13 @@ func TestPipelineSave_missingid(t *testing.T) {
 
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -204,13 +204,13 @@ func TestPipelineSave_missingapp(t *testing.T) {
 
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := getRootCmdForTest()
+	rootCmd := util.NewRootCmdForTest()
 	pipelineCmd := NewPipelineCmd(os.Stdout)
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
 	rootCmd.SetArgs(args)
-	err := rootCmd.Execute()
+	_, err := util.ExecCmdForTest(rootCmd)
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/pipeline/save_test.go
+++ b/cmd/pipeline/save_test.go
@@ -15,19 +15,23 @@
 package pipeline
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
-func TestPipelineSave_basic(t *testing.T) {
-	ts := GateServerSuccess()
+func TestPipelineSave_json(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineSaveSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(testPipelineJsonStr)
@@ -46,10 +50,42 @@ func TestPipelineSave_basic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testPipelineJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
+}
+
+func TestPipelineSave_yaml(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineSaveSuccess(saveBuffer)
+	defer ts.Close()
+
+	tempFile := tempPipelineFile(testPipelineYamlStr)
+	if tempFile == nil {
+		t.Fatal("Could not create temp pipeline file.")
+	}
+	defer os.Remove(tempFile.Name())
+
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
+	rootCmd.AddCommand(pipelineCmd)
+
+	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(testPipelineJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestPipelineSave_stdin(t *testing.T) {
-	ts := GateServerSuccess()
+	saveBuffer := new(bytes.Buffer)
+	ts := testGatePipelineSaveSuccess(saveBuffer)
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(testPipelineJsonStr)
@@ -74,10 +110,14 @@ func TestPipelineSave_stdin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
+
+	expected := strings.TrimSpace(testPipelineJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
 }
 
 func TestPipelineSave_fail(t *testing.T) {
-	ts := GateServerFail()
+	ts := testGateFail()
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(testPipelineJsonStr)
@@ -99,7 +139,7 @@ func TestPipelineSave_fail(t *testing.T) {
 }
 
 func TestPipelineSave_accessdenied(t *testing.T) {
-	ts := GateServerReadOnly()
+	ts := testGateReadOnly()
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(testPipelineJsonStr)
@@ -120,7 +160,7 @@ func TestPipelineSave_accessdenied(t *testing.T) {
 	}
 }
 func TestPipelineSave_flags(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
@@ -136,7 +176,7 @@ func TestPipelineSave_flags(t *testing.T) {
 }
 
 func TestPipelineSave_missingname(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(missingNameJsonStr)
@@ -158,7 +198,7 @@ func TestPipelineSave_missingname(t *testing.T) {
 }
 
 func TestPipelineSave_missingid(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(missingIdJsonStr)
@@ -180,7 +220,7 @@ func TestPipelineSave_missingid(t *testing.T) {
 }
 
 func TestPipelineSave_missingapp(t *testing.T) {
-	ts := GateServerSuccess()
+	ts := testGateSuccess()
 	defer ts.Close()
 
 	tempFile := tempPipelineFile(missingAppJsonStr)
@@ -211,9 +251,28 @@ func tempPipelineFile(pipelineContent string) *os.File {
 	return tempFile
 }
 
-// GateServerSuccess spins up a local http server that we will configure the GateClient
+// testGatePipelineSaveSuccess spins up a local http server that we will configure the
+// GateClient to direct requests to. Responds with a 200 OK.
+// Writes pipeline body to buffer for testing.
+func testGatePipelineSaveSuccess(buffer io.Writer) *httptest.Server {
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle(
+		"/applications/app/pipelineConfigs/pipeline1",
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Confirm the pipeline exists.
+			fmt.Fprintln(w, "")
+		}),
+	)
+	mux.Handle(
+		"/pipelines",
+		util.NewTestBufferHandlerFunc(http.MethodPost, buffer, http.StatusOK, ""),
+	)
+	return httptest.NewServer(mux)
+}
+
+// testGateSuccess spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 200 OK.
-func GateServerSuccess() *httptest.Server {
+func testGateSuccess() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "") // Just write an empty 200 success on save.
@@ -221,9 +280,9 @@ func GateServerSuccess() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// GateServerReadOnly spins up a local http server that we will configure the GateClient
+// testGateReadOnly spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 200 OK for READ-type requests (GET), 400 otherwise.
-func GateServerReadOnly() *httptest.Server {
+func testGateReadOnly() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch method := r.Method; method {
@@ -237,9 +296,9 @@ func GateServerReadOnly() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
-// GateServerFail spins up a local http server that we will configure the GateClient
+// testGateFail spins up a local http server that we will configure the GateClient
 // to direct requests to. Responds with a 500 InternalServerError.
-func GateServerFail() *httptest.Server {
+func testGateFail() *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
@@ -313,31 +372,54 @@ const missingAppJsonStr = `
 
 const testPipelineJsonStr = `
 {
-  "name": "pipeline1",
-  "id": "pipeline1",
-  "application": "app",
-  "keepWaitingPipelines": false,
-  "lastModifiedBy": "anonymous",
-  "limitConcurrent": true,
-  "parameterConfig": [
-    {
-      "default": "bar",
-      "description": "A foo.",
-      "name": "foo",
-      "required": true
-    }
-  ],
-  "stages": [
-    {
-      "comments": "${ parameters.derp }",
-      "name": "Wait",
-      "refId": "1",
-      "requisiteStageRefIds": [],
-      "type": "wait",
-      "waitTime": 30
-    }
-  ],
-  "triggers": [],
-  "updateTs": "1520879791608"
+ "application": "app",
+ "id": "pipeline1",
+ "keepWaitingPipelines": false,
+ "lastModifiedBy": "anonymous",
+ "limitConcurrent": true,
+ "name": "pipeline1",
+ "parameterConfig": [
+  {
+   "default": "bar",
+   "description": "A foo.",
+   "name": "foo",
+   "required": true
+  }
+ ],
+ "stages": [
+  {
+   "comments": "${ parameters.derp }",
+   "name": "Wait",
+   "refId": "1",
+   "requisiteStageRefIds": [],
+   "type": "wait",
+   "waitTime": 30
+  }
+ ],
+ "triggers": [],
+ "updateTs": "1520879791608"
 }
+`
+
+const testPipelineYamlStr = `
+name: pipeline1
+id: pipeline1
+application: app
+keepWaitingPipelines: false
+lastModifiedBy: anonymous
+limitConcurrent: true
+parameterConfig:
+- default: bar
+  description: A foo.
+  name: foo
+  required: true
+stages:
+- comments: ${ parameters.derp }
+  name: Wait
+  refId: "1"
+  requisiteStageRefIds: []
+  type: wait
+  waitTime: 30
+triggers: []
+updateTs: "1520879791608"
 `

--- a/cmd/pipeline/save_test.go
+++ b/cmd/pipeline/save_test.go
@@ -38,7 +38,7 @@ func TestPipelineSave_basic(t *testing.T) {
 
 	currentCmd := NewSaveCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -68,7 +68,7 @@ func TestPipelineSave_stdin(t *testing.T) {
 	args := []string{"pipeline", "save", "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -92,7 +92,7 @@ func TestPipelineSave_fail(t *testing.T) {
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -116,7 +116,7 @@ func TestPipelineSave_accessdenied(t *testing.T) {
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -133,7 +133,7 @@ func TestPipelineSave_flags(t *testing.T) {
 	args := []string{"pipeline", "save", "--gate-endpoint", ts.URL} // Missing pipeline spec file.
 	currentCmd := NewSaveCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -157,7 +157,7 @@ func TestPipelineSave_missingname(t *testing.T) {
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -181,7 +181,7 @@ func TestPipelineSave_missingid(t *testing.T) {
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 
@@ -205,7 +205,7 @@ func TestPipelineSave_missingapp(t *testing.T) {
 	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	currentCmd := NewSaveCmd(pipelineOptions{})
 	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd(os.Stdout)
+	pipelineCmd := NewPipelineCmd()
 	pipelineCmd.AddCommand(currentCmd)
 	rootCmd.AddCommand(pipelineCmd)
 

--- a/cmd/pipeline/save_test.go
+++ b/cmd/pipeline/save_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spinnaker/spin/cmd"
 	"github.com/spinnaker/spin/util"
 )
 
@@ -34,16 +35,14 @@ func TestPipelineSave_basic(t *testing.T) {
 		t.Fatal("Could not create temp pipeline file.")
 	}
 	defer os.Remove(tempFile.Name())
-	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 
-	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -65,15 +64,13 @@ func TestPipelineSave_stdin(t *testing.T) {
 	defer func() { os.Stdin = oldStdin }()
 	os.Stdin = tempFile
 
-	args := []string{"pipeline", "save", "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "save", "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -89,15 +86,13 @@ func TestPipelineSave_fail(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -113,15 +108,13 @@ func TestPipelineSave_accessdenied(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -130,15 +123,13 @@ func TestPipelineSave_flags(t *testing.T) {
 	ts := GateServerSuccess()
 	defer ts.Close()
 
-	args := []string{"pipeline", "save", "--gate-endpoint", ts.URL} // Missing pipeline spec file.
-	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "save", "--gate-endpoint", ts.URL} // Missing pipeline spec file.
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -154,15 +145,13 @@ func TestPipelineSave_missingname(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -178,15 +167,13 @@ func TestPipelineSave_missingid(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
@@ -202,15 +189,13 @@ func TestPipelineSave_missingapp(t *testing.T) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
-	currentCmd := NewSaveCmd(pipelineOptions{})
-	rootCmd := util.NewRootCmdForTest()
-	pipelineCmd := NewPipelineCmd()
-	pipelineCmd.AddCommand(currentCmd)
+	rootCmd, rootOpts := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	pipelineCmd, _ := NewPipelineCmd(rootOpts)
 	rootCmd.AddCommand(pipelineCmd)
 
+	args := []string{"pipeline", "save", "--file", tempFile.Name(), "--gate-endpoint", ts.URL}
 	rootCmd.SetArgs(args)
-	_, err := util.ExecCmdForTest(rootCmd)
+	err := rootCmd.Execute()
 	if err == nil {
 		t.Fatalf("Command failed with: %s", err)
 	}

--- a/cmd/project/get.go
+++ b/cmd/project/get.go
@@ -16,8 +16,9 @@ package project
 
 import (
 	"fmt"
-	"github.com/spinnaker/spin/util"
 	"net/http"
+
+	"github.com/spinnaker/spin/util"
 
 	"github.com/spf13/cobra"
 	"github.com/spinnaker/spin/cmd/gateclient"
@@ -37,7 +38,7 @@ var (
 func NewGetCmd(prjOptions projectOptions) *cobra.Command {
 	options := GetOptions{
 		projectOptions: &prjOptions,
-		expand: false,
+		expand:         false,
 	}
 
 	cmd := &cobra.Command{
@@ -45,7 +46,7 @@ func NewGetCmd(prjOptions projectOptions) *cobra.Command {
 		Short:   getProjectShort,
 		Long:    getProjectLong,
 		Example: getProjectExample,
-		RunE:    func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			return getProject(cmd, options, args)
 		},
 	}
@@ -67,7 +68,7 @@ func getProject(cmd *cobra.Command, options GetOptions, args []string) error {
 	project, resp, err := gateClient.ProjectControllerApi.AllPipelinesForProjectUsingGET(gateClient.Context, projectName, map[string]interface{}{"expand": options.expand})
 	if resp != nil {
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Project '%s' not found\n",projectName)
+			return fmt.Errorf("Project '%s' not found\n", projectName)
 		} else if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("Encountered an error getting project, status code: %d\n", resp.StatusCode)
 		}

--- a/cmd/project/get.go
+++ b/cmd/project/get.go
@@ -21,10 +21,9 @@ import (
 	"github.com/spinnaker/spin/util"
 
 	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/gateclient"
 )
 
-type GetOptions struct {
+type getOptions struct {
 	*projectOptions
 	expand bool
 }
@@ -35,9 +34,9 @@ var (
 	getProjectExample = "usage: spin project get-pipelines [options] project-name"
 )
 
-func NewGetCmd(prjOptions projectOptions) *cobra.Command {
-	options := GetOptions{
-		projectOptions: &prjOptions,
+func NewGetCmd(prjOptions *projectOptions) *cobra.Command {
+	options := &getOptions{
+		projectOptions: prjOptions,
 		expand:         false,
 	}
 
@@ -54,18 +53,13 @@ func NewGetCmd(prjOptions projectOptions) *cobra.Command {
 	return cmd
 }
 
-func getProject(cmd *cobra.Command, options GetOptions, args []string) error {
-	gateClient, err := gateclient.NewGateClient(cmd.InheritedFlags())
-	if err != nil {
-		return err
-	}
-
+func getProject(cmd *cobra.Command, options *getOptions, args []string) error {
 	projectName, err := util.ReadArgsOrStdin(args)
 	if err != nil {
 		return err
 	}
 
-	project, resp, err := gateClient.ProjectControllerApi.AllPipelinesForProjectUsingGET(gateClient.Context, projectName, map[string]interface{}{"expand": options.expand})
+	project, resp, err := options.GateClient.ProjectControllerApi.AllPipelinesForProjectUsingGET(options.GateClient.Context, projectName, map[string]interface{}{"expand": options.expand})
 	if resp != nil {
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Project '%s' not found\n", projectName)
@@ -77,7 +71,7 @@ func getProject(cmd *cobra.Command, options GetOptions, args []string) error {
 	if err != nil {
 		return err
 	}
-	util.UI.JsonOutput(project)
+	options.Ui.JsonOutput(project)
 
 	return nil
 }

--- a/cmd/project/get.go
+++ b/cmd/project/get.go
@@ -77,7 +77,7 @@ func getProject(cmd *cobra.Command, options GetOptions, args []string) error {
 	if err != nil {
 		return err
 	}
-	util.UI.JsonOutput(project, util.UI.OutputFormat)
+	util.UI.JsonOutput(project)
 
 	return nil
 }

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -1,8 +1,6 @@
 package project
 
 import (
-	"io"
-
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +13,7 @@ var (
 	projectExample = ""
 )
 
-func NewProjectCmd(out io.Writer) *cobra.Command {
+func NewProjectCmd() *cobra.Command {
 	options := projectOptions{}
 	cmd := &cobra.Command{
 		Use:     "project",

--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -2,9 +2,11 @@ package project
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd"
 )
 
 type projectOptions struct {
+	*cmd.RootOptions
 }
 
 var (
@@ -13,8 +15,10 @@ var (
 	projectExample = ""
 )
 
-func NewProjectCmd() *cobra.Command {
-	options := projectOptions{}
+func NewProjectCmd(rootOptions *cmd.RootOptions) *cobra.Command {
+	options := &projectOptions{
+		RootOptions: rootOptions,
+	}
 	cmd := &cobra.Command{
 		Use:     "project",
 		Aliases: []string{"project", "prj"},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,12 +24,7 @@ type RootOptions struct {
 	defaultHeaders   string
 }
 
-func Execute(out io.Writer) error {
-	cmd := NewCmdRoot(out)
-	return cmd.Execute()
-}
-
-func NewCmdRoot(out io.Writer) *cobra.Command {
+func NewCmdRoot(out, err io.Writer) *cobra.Command {
 	options := RootOptions{}
 
 	cmd := &cobra.Command{
@@ -37,6 +32,9 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 		SilenceErrors: true,
 		Version:       version.String(),
 	}
+
+	cmd.SetOut(out)
+	cmd.SetErr(err)
 
 	cmd.PersistentFlags().StringVar(&options.configFile, "config", "", "path to config file (default $HOME/.spin/config)")
 	cmd.PersistentFlags().StringVar(&options.GateEndpoint, "gate-endpoint", "", "Gate (API server) endpoint (default http://localhost:8084)")
@@ -47,12 +45,12 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&options.defaultHeaders, "default-headers", "", "configure default headers for gate client as comma separated list (e.g. key1=value1,key2=value2)")
 
 	// create subcommands
-	cmd.AddCommand(application.NewApplicationCmd(out))
-	cmd.AddCommand(canary.NewCanaryCmd(out))
-	cmd.AddCommand(pipeline.NewPipelineCmd(out))
-	cmd.AddCommand(pipeline_template.NewPipelineTemplateCmd(out))
-	cmd.AddCommand(project.NewProjectCmd(out))
-	cmd.AddCommand(account.NewAccountCmd(out))
+	cmd.AddCommand(application.NewApplicationCmd())
+	cmd.AddCommand(canary.NewCanaryCmd())
+	cmd.AddCommand(pipeline.NewPipelineCmd())
+	cmd.AddCommand(pipeline_template.NewPipelineTemplateCmd())
+	cmd.AddCommand(project.NewProjectCmd())
+	cmd.AddCommand(account.NewAccountCmd())
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ type RootOptions struct {
 	GateClient *gateclient.GatewayClient
 }
 
+//TODO(karlkfi): Pipe stdin reader through NewCmdRoot for testing
 func NewCmdRoot(outWriter, errWriter io.Writer) (*cobra.Command, *RootOptions) {
 	options := &RootOptions{}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ func NewCmdRoot(out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&options.ignoreCertErrors, "insecure", "k", false, "ignore certificate errors")
 	cmd.PersistentFlags().BoolVarP(&options.quiet, "quiet", "q", false, "squelch non-essential output")
 	cmd.PersistentFlags().BoolVar(&options.color, "no-color", true, "disable color")
-	cmd.PersistentFlags().StringVar(&options.outputFormat, "output", "", "configure output formatting")
+	cmd.PersistentFlags().StringVarP(&options.outputFormat, "output", "o", "", "configure output formatting")
 	cmd.PersistentFlags().StringVar(&options.defaultHeaders, "default-headers", "", "configure default headers for gate client as comma separated list (e.g. key1=value1,key2=value2)")
 
 	// create subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spinnaker/spin/cmd/gateclient"
 	"github.com/spinnaker/spin/cmd/output"
-	"github.com/spinnaker/spin/util"
 	"github.com/spinnaker/spin/version"
 )
 
@@ -20,7 +19,7 @@ type RootOptions struct {
 	outputFormat     string
 	defaultHeaders   string
 
-	Ui         util.Ui
+	Ui         output.Ui
 	GateClient *gateclient.GatewayClient
 }
 
@@ -56,7 +55,7 @@ func NewCmdRoot(outWriter, errWriter io.Writer) (*cobra.Command, *RootOptions) {
 		if err != nil {
 			return err
 		}
-		options.Ui = util.NewUI(options.quiet, options.color, outputFormater, outw, errw)
+		options.Ui = output.NewUI(options.quiet, options.color, outputFormater, outw, errw)
 
 		gateClient, err := gateclient.NewGateClient(
 			options.Ui,

--- a/gateapi/account.go
+++ b/gateapi/account.go
@@ -10,7 +10,6 @@
 package swagger
 
 type Account struct {
-
 	Skin string `json:"skin,omitempty"`
 
 	RequiredGroupMembership []string `json:"requiredGroupMembership,omitempty"`

--- a/gateapi/account_details.go
+++ b/gateapi/account_details.go
@@ -10,7 +10,6 @@
 package swagger
 
 type AccountDetails struct {
-
 	Permissions map[string][]string `json:"permissions,omitempty"`
 
 	PrimaryAccount bool `json:"primaryAccount,omitempty"`

--- a/gateapi/amazon_infrastructure_controller_api.go
+++ b/gateapi/amazon_infrastructure_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,18 +27,17 @@ var (
 
 type AmazonInfrastructureControllerApiService service
 
-
 /* AmazonInfrastructureControllerApiService Get application functions
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @return []interface{}*/
-func (a *AmazonInfrastructureControllerApiService) ApplicationFunctionsUsingGET(ctx context.Context, application string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@return []interface{}*/
+func (a *AmazonInfrastructureControllerApiService) ApplicationFunctionsUsingGET(ctx context.Context, application string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -48,9 +48,8 @@ func (a *AmazonInfrastructureControllerApiService) ApplicationFunctionsUsingGET(
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -61,7 +60,7 @@ func (a *AmazonInfrastructureControllerApiService) ApplicationFunctionsUsingGET(
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -87,24 +86,23 @@ func (a *AmazonInfrastructureControllerApiService) ApplicationFunctionsUsingGET(
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* AmazonInfrastructureControllerApiService Get functions
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "account" (string) account
-     @param "functionName" (string) functionName
-     @param "region" (string) region
- @return []interface{}*/
-func (a *AmazonInfrastructureControllerApiService) FunctionsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "account" (string) account
+    @param "functionName" (string) functionName
+    @param "region" (string) region
+@return []interface{}*/
+func (a *AmazonInfrastructureControllerApiService) FunctionsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -134,7 +132,7 @@ func (a *AmazonInfrastructureControllerApiService) FunctionsUsingGET(ctx context
 		localVarQueryParams.Add("region", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -145,7 +143,7 @@ func (a *AmazonInfrastructureControllerApiService) FunctionsUsingGET(ctx context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -171,20 +169,19 @@ func (a *AmazonInfrastructureControllerApiService) FunctionsUsingGET(ctx context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* AmazonInfrastructureControllerApiService Get instance types
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *AmazonInfrastructureControllerApiService) InstanceTypesUsingGET(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *AmazonInfrastructureControllerApiService) InstanceTypesUsingGET(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -194,9 +191,8 @@ func (a *AmazonInfrastructureControllerApiService) InstanceTypesUsingGET(ctx con
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -207,7 +203,7 @@ func (a *AmazonInfrastructureControllerApiService) InstanceTypesUsingGET(ctx con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -233,20 +229,19 @@ func (a *AmazonInfrastructureControllerApiService) InstanceTypesUsingGET(ctx con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* AmazonInfrastructureControllerApiService Get subnets
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *AmazonInfrastructureControllerApiService) SubnetsUsingGET(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *AmazonInfrastructureControllerApiService) SubnetsUsingGET(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -256,9 +251,8 @@ func (a *AmazonInfrastructureControllerApiService) SubnetsUsingGET(ctx context.C
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -269,7 +263,7 @@ func (a *AmazonInfrastructureControllerApiService) SubnetsUsingGET(ctx context.C
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -295,20 +289,19 @@ func (a *AmazonInfrastructureControllerApiService) SubnetsUsingGET(ctx context.C
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* AmazonInfrastructureControllerApiService Get VPCs
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *AmazonInfrastructureControllerApiService) VpcsUsingGET(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *AmazonInfrastructureControllerApiService) VpcsUsingGET(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -318,9 +311,8 @@ func (a *AmazonInfrastructureControllerApiService) VpcsUsingGET(ctx context.Cont
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -331,7 +323,7 @@ func (a *AmazonInfrastructureControllerApiService) VpcsUsingGET(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -357,7 +349,5 @@ func (a *AmazonInfrastructureControllerApiService) VpcsUsingGET(ctx context.Cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/api_client.go
+++ b/gateapi/api_client.go
@@ -13,71 +13,72 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
-	"fmt"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
-    "golang.org/x/oauth2"
-    "golang.org/x/net/context"
 	"net/http"
 	"net/url"
-	"time"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strings"
-	"unicode/utf8"
 	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
 )
 
 var (
 	jsonCheck = regexp.MustCompile("(?i:[application|text]/json)")
-	xmlCheck = regexp.MustCompile("(?i:[application|text]/xml)")
+	xmlCheck  = regexp.MustCompile("(?i:[application|text]/xml)")
 )
 
 // APIClient manages communication with the Spinnaker API API v1.0.0
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
-	cfg 	*Configuration
-	common 	service 		// Reuse a single struct instead of allocating one for each service on the heap.
+	cfg    *Configuration
+	common service // Reuse a single struct instead of allocating one for each service on the heap.
 
-	 // API Services
-	AmazonInfrastructureControllerApi	*AmazonInfrastructureControllerApiService
-	ApplicationControllerApi	*ApplicationControllerApiService
-	ArtifactControllerApi	*ArtifactControllerApiService
-	AuthControllerApi	*AuthControllerApiService
-	BakeControllerApi	*BakeControllerApiService
-	BuildControllerApi	*BuildControllerApiService
-	ClusterControllerApi	*ClusterControllerApiService
-	ConcourseControllerApi	*ConcourseControllerApiService
-	CredentialsControllerApi	*CredentialsControllerApiService
-	EcsServerGroupEventsControllerApi	*EcsServerGroupEventsControllerApiService
-	ExecutionsControllerApi	*ExecutionsControllerApiService
-	FirewallControllerApi	*FirewallControllerApiService
-	ImageControllerApi	*ImageControllerApiService
-	InstanceControllerApi	*InstanceControllerApiService
-	JobControllerApi	*JobControllerApiService
-	LoadBalancerControllerApi	*LoadBalancerControllerApiService
-	NetworkControllerApi	*NetworkControllerApiService
-	PipelineConfigControllerApi	*PipelineConfigControllerApiService
-	PipelineControllerApi	*PipelineControllerApiService
-	PipelineTemplatesControllerApi	*PipelineTemplatesControllerApiService
-	ProjectControllerApi	*ProjectControllerApiService
-	PubsubSubscriptionControllerApi	*PubsubSubscriptionControllerApiService
-	ReorderPipelinesControllerApi	*ReorderPipelinesControllerApiService
-	SearchControllerApi	*SearchControllerApiService
-	SecurityGroupControllerApi	*SecurityGroupControllerApiService
-	ServerGroupControllerApi	*ServerGroupControllerApiService
-	ServerGroupManagerControllerApi	*ServerGroupManagerControllerApiService
-	SnapshotControllerApi	*SnapshotControllerApiService
-	SubnetControllerApi	*SubnetControllerApiService
-	TaskControllerApi	*TaskControllerApiService
-	V2CanaryConfigControllerApi	*V2CanaryConfigControllerApiService
-	V2CanaryControllerApi	*V2CanaryControllerApiService
-	V2PipelineTemplatesControllerApi	*V2PipelineTemplatesControllerApiService
-	VersionControllerApi	*VersionControllerApiService
-	WebhookControllerApi	*WebhookControllerApiService
+	// API Services
+	AmazonInfrastructureControllerApi *AmazonInfrastructureControllerApiService
+	ApplicationControllerApi          *ApplicationControllerApiService
+	ArtifactControllerApi             *ArtifactControllerApiService
+	AuthControllerApi                 *AuthControllerApiService
+	BakeControllerApi                 *BakeControllerApiService
+	BuildControllerApi                *BuildControllerApiService
+	ClusterControllerApi              *ClusterControllerApiService
+	ConcourseControllerApi            *ConcourseControllerApiService
+	CredentialsControllerApi          *CredentialsControllerApiService
+	EcsServerGroupEventsControllerApi *EcsServerGroupEventsControllerApiService
+	ExecutionsControllerApi           *ExecutionsControllerApiService
+	FirewallControllerApi             *FirewallControllerApiService
+	ImageControllerApi                *ImageControllerApiService
+	InstanceControllerApi             *InstanceControllerApiService
+	JobControllerApi                  *JobControllerApiService
+	LoadBalancerControllerApi         *LoadBalancerControllerApiService
+	NetworkControllerApi              *NetworkControllerApiService
+	PipelineConfigControllerApi       *PipelineConfigControllerApiService
+	PipelineControllerApi             *PipelineControllerApiService
+	PipelineTemplatesControllerApi    *PipelineTemplatesControllerApiService
+	ProjectControllerApi              *ProjectControllerApiService
+	PubsubSubscriptionControllerApi   *PubsubSubscriptionControllerApiService
+	ReorderPipelinesControllerApi     *ReorderPipelinesControllerApiService
+	SearchControllerApi               *SearchControllerApiService
+	SecurityGroupControllerApi        *SecurityGroupControllerApiService
+	ServerGroupControllerApi          *ServerGroupControllerApiService
+	ServerGroupManagerControllerApi   *ServerGroupManagerControllerApiService
+	SnapshotControllerApi             *SnapshotControllerApiService
+	SubnetControllerApi               *SubnetControllerApiService
+	TaskControllerApi                 *TaskControllerApiService
+	V2CanaryConfigControllerApi       *V2CanaryConfigControllerApiService
+	V2CanaryControllerApi             *V2CanaryControllerApiService
+	V2PipelineTemplatesControllerApi  *V2PipelineTemplatesControllerApiService
+	VersionControllerApi              *VersionControllerApiService
+	WebhookControllerApi              *WebhookControllerApiService
 }
 
 type service struct {
@@ -138,7 +139,6 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 func atoi(in string) (int, error) {
 	return strconv.Atoi(in)
 }
-
 
 // selectHeaderContentType select a content type from the available list.
 func selectHeaderContentType(contentTypes []string) string {
@@ -210,18 +210,18 @@ func parameterToString(obj interface{}, collectionFormat string) string {
 	return fmt.Sprintf("%v", obj)
 }
 
-// callAPI do the request. 
+// callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
-	 return c.cfg.HTTPClient.Do(request)
+	return c.cfg.HTTPClient.Do(request)
 }
 
 // Change base path to allow switching to mocks
-func (c *APIClient) ChangeBasePath (path string) {
+func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
 // prepareRequest build the request
-func (c *APIClient) prepareRequest (
+func (c *APIClient) prepareRequest(
 	ctx context.Context,
 	path string, method string,
 	postBody interface{},
@@ -281,7 +281,7 @@ func (c *APIClient) prepareRequest (
 			// Set the Boundary in the Content-Type
 			headerParams["Content-Type"] = w.FormDataContentType()
 		}
-		
+
 		// Set Content-Length
 		headerParams["Content-Length"] = fmt.Sprintf("%d", body.Len())
 		w.Close()
@@ -327,10 +327,9 @@ func (c *APIClient) prepareRequest (
 	if c.cfg.Host != "" {
 		localVarRequest.Host = c.cfg.Host
 	}
-	
+
 	// Add the user agent to the request.
 	localVarRequest.Header.Add("User-Agent", c.cfg.UserAgent)
-	
 
 	if ctx != nil {
 		// add context to the request
@@ -356,17 +355,16 @@ func (c *APIClient) prepareRequest (
 
 		// AccessToken Authentication
 		if auth, ok := ctx.Value(ContextAccessToken).(string); ok {
-			localVarRequest.Header.Add("Authorization", "Bearer " + auth)
+			localVarRequest.Header.Add("Authorization", "Bearer "+auth)
 		}
 	}
 
 	for header, value := range c.cfg.DefaultHeader {
 		localVarRequest.Header.Add(header, value)
 	}
-	
+
 	return localVarRequest, nil
 }
-
 
 // Add a file to the multipart request
 func addFile(w *multipart.Writer, fieldName, path string) error {
@@ -386,7 +384,7 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 }
 
 // Prevent trying to import "fmt"
-func reportError(format string, a ...interface{}) (error) {
+func reportError(format string, a ...interface{}) error {
 	return fmt.Errorf(format, a...)
 }
 
@@ -423,7 +421,7 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 func detectContentType(body interface{}) string {
 	contentType := "text/plain; charset=utf-8"
 	kind := reflect.TypeOf(body).Kind()
-	
+
 	switch kind {
 	case reflect.Struct, reflect.Map, reflect.Ptr:
 		contentType = "application/json; charset=utf-8"
@@ -439,7 +437,6 @@ func detectContentType(body interface{}) string {
 
 	return contentType
 }
-
 
 // Ripped from https://github.com/gregjones/httpcache/blob/master/httpcache.go
 type cacheControl map[string]string
@@ -463,7 +460,7 @@ func parseCacheControl(headers http.Header) cacheControl {
 }
 
 // CacheExpires helper function to determine remaining time before repeating a request.
-func CacheExpires(r *http.Response) (time.Time) {
+func CacheExpires(r *http.Response) time.Time {
 	// Figure out when the cache expires.
 	var expires time.Time
 	now, err := time.Parse(time.RFC1123, r.Header.Get("date"))
@@ -471,7 +468,7 @@ func CacheExpires(r *http.Response) (time.Time) {
 		return time.Now()
 	}
 	respCacheControl := parseCacheControl(r.Header)
-	
+
 	if maxAge, ok := respCacheControl["max-age"]; ok {
 		lifetime, err := time.ParseDuration(maxAge + "s")
 		if err != nil {
@@ -490,7 +487,6 @@ func CacheExpires(r *http.Response) (time.Time) {
 	return expires
 }
 
-func strlen(s string) (int) {
+func strlen(s string) int {
 	return utf8.RuneCountInString(s)
 }
-

--- a/gateapi/api_response.go
+++ b/gateapi/api_response.go
@@ -15,15 +15,15 @@ import (
 
 type APIResponse struct {
 	*http.Response `json:"-"`
-	Message string `json:"message,omitempty"`
+	Message        string `json:"message,omitempty"`
 	// Operation is the name of the swagger operation.
-	Operation       string `json:"operation,omitempty"`
+	Operation string `json:"operation,omitempty"`
 	// RequestURL is the request URL. This value is always available, even if the
 	// embedded *http.Response is nil.
-	RequestURL      string `json:"url,omitempty"`
+	RequestURL string `json:"url,omitempty"`
 	// Method is the HTTP method used for the request.  This value is always
 	// available, even if the embedded *http.Response is nil.
-	Method          string `json:"method,omitempty"`
+	Method string `json:"method,omitempty"`
 	// Payload holds the contents of the response body (which may be nil or empty).
 	// This is provided here as the raw response.Body() reader will have already
 	// been drained.

--- a/gateapi/application_controller_api.go
+++ b/gateapi/application_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,20 +27,19 @@ var (
 
 type ApplicationControllerApiService service
 
-
 /* ApplicationControllerApiService Cancel pipeline
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "reason" (string) reason
- @return map[string]interface{}*/
-func (a *ApplicationControllerApiService) CancelPipelineUsingPUT(ctx context.Context, id string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "reason" (string) reason
+@return map[string]interface{}*/
+func (a *ApplicationControllerApiService) CancelPipelineUsingPUT(ctx context.Context, id string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -58,7 +58,7 @@ func (a *ApplicationControllerApiService) CancelPipelineUsingPUT(ctx context.Con
 		localVarQueryParams.Add("reason", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -69,7 +69,7 @@ func (a *ApplicationControllerApiService) CancelPipelineUsingPUT(ctx context.Con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -95,21 +95,20 @@ func (a *ApplicationControllerApiService) CancelPipelineUsingPUT(ctx context.Con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Cancel task
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *ApplicationControllerApiService) CancelTaskUsingPUT(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *ApplicationControllerApiService) CancelTaskUsingPUT(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -120,9 +119,8 @@ func (a *ApplicationControllerApiService) CancelTaskUsingPUT(ctx context.Context
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -133,7 +131,7 @@ func (a *ApplicationControllerApiService) CancelTaskUsingPUT(ctx context.Context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -159,23 +157,22 @@ func (a *ApplicationControllerApiService) CancelTaskUsingPUT(ctx context.Context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve a list of applications
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "account" (string) filters results to only include applications deployed in the specified account
-     @param "owner" (string) filteres results to only include applications owned by the specified email
- @return []interface{}*/
-func (a *ApplicationControllerApiService) GetAllApplicationsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "account" (string) filters results to only include applications deployed in the specified account
+    @param "owner" (string) filteres results to only include applications owned by the specified email
+@return []interface{}*/
+func (a *ApplicationControllerApiService) GetAllApplicationsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -199,7 +196,7 @@ func (a *ApplicationControllerApiService) GetAllApplicationsUsingGET(ctx context
 		localVarQueryParams.Add("owner", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -210,7 +207,7 @@ func (a *ApplicationControllerApiService) GetAllApplicationsUsingGET(ctx context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -236,23 +233,22 @@ func (a *ApplicationControllerApiService) GetAllApplicationsUsingGET(ctx context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve a list of an application&#39;s configuration revision history
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "limit" (int32) limit
- @return []interface{}*/
-func (a *ApplicationControllerApiService) GetApplicationHistoryUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "limit" (int32) limit
+@return []interface{}*/
+func (a *ApplicationControllerApiService) GetApplicationHistoryUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -271,7 +267,7 @@ func (a *ApplicationControllerApiService) GetApplicationHistoryUsingGET(ctx cont
 		localVarQueryParams.Add("limit", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -282,7 +278,7 @@ func (a *ApplicationControllerApiService) GetApplicationHistoryUsingGET(ctx cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -308,23 +304,22 @@ func (a *ApplicationControllerApiService) GetApplicationHistoryUsingGET(ctx cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve an application&#39;s details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "expand" (bool) expand
- @return map[string]interface{}*/
-func (a *ApplicationControllerApiService) GetApplicationUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "expand" (bool) expand
+@return map[string]interface{}*/
+func (a *ApplicationControllerApiService) GetApplicationUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -343,7 +338,7 @@ func (a *ApplicationControllerApiService) GetApplicationUsingGET(ctx context.Con
 		localVarQueryParams.Add("expand", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -354,7 +349,7 @@ func (a *ApplicationControllerApiService) GetApplicationUsingGET(ctx context.Con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -380,22 +375,21 @@ func (a *ApplicationControllerApiService) GetApplicationUsingGET(ctx context.Con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve a pipeline configuration
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param pipelineName pipelineName
- @return map[string]interface{}*/
-func (a *ApplicationControllerApiService) GetPipelineConfigUsingGET(ctx context.Context, application string, pipelineName string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param pipelineName pipelineName
+@return map[string]interface{}*/
+func (a *ApplicationControllerApiService) GetPipelineConfigUsingGET(ctx context.Context, application string, pipelineName string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -407,9 +401,8 @@ func (a *ApplicationControllerApiService) GetPipelineConfigUsingGET(ctx context.
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -420,7 +413,7 @@ func (a *ApplicationControllerApiService) GetPipelineConfigUsingGET(ctx context.
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -446,21 +439,20 @@ func (a *ApplicationControllerApiService) GetPipelineConfigUsingGET(ctx context.
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve a list of an application&#39;s pipeline configurations
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @return []interface{}*/
-func (a *ApplicationControllerApiService) GetPipelineConfigsForApplicationUsingGET(ctx context.Context, application string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@return []interface{}*/
+func (a *ApplicationControllerApiService) GetPipelineConfigsForApplicationUsingGET(ctx context.Context, application string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -471,9 +463,8 @@ func (a *ApplicationControllerApiService) GetPipelineConfigsForApplicationUsingG
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -484,7 +475,7 @@ func (a *ApplicationControllerApiService) GetPipelineConfigsForApplicationUsingG
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -510,25 +501,24 @@ func (a *ApplicationControllerApiService) GetPipelineConfigsForApplicationUsingG
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve a list of an application&#39;s pipeline executions
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "expand" (bool) expand
-     @param "limit" (int32) limit
-     @param "statuses" (string) statuses
- @return []interface{}*/
-func (a *ApplicationControllerApiService) GetPipelinesUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "expand" (bool) expand
+    @param "limit" (int32) limit
+    @param "statuses" (string) statuses
+@return []interface{}*/
+func (a *ApplicationControllerApiService) GetPipelinesUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -559,7 +549,7 @@ func (a *ApplicationControllerApiService) GetPipelinesUsingGET(ctx context.Conte
 		localVarQueryParams.Add("statuses", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -570,7 +560,7 @@ func (a *ApplicationControllerApiService) GetPipelinesUsingGET(ctx context.Conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -596,22 +586,21 @@ func (a *ApplicationControllerApiService) GetPipelinesUsingGET(ctx context.Conte
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve a pipeline strategy configuration
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param strategyName strategyName
- @return map[string]interface{}*/
-func (a *ApplicationControllerApiService) GetStrategyConfigUsingGET(ctx context.Context, application string, strategyName string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param strategyName strategyName
+@return map[string]interface{}*/
+func (a *ApplicationControllerApiService) GetStrategyConfigUsingGET(ctx context.Context, application string, strategyName string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -623,9 +612,8 @@ func (a *ApplicationControllerApiService) GetStrategyConfigUsingGET(ctx context.
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -636,7 +624,7 @@ func (a *ApplicationControllerApiService) GetStrategyConfigUsingGET(ctx context.
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -662,21 +650,20 @@ func (a *ApplicationControllerApiService) GetStrategyConfigUsingGET(ctx context.
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve a list of an application&#39;s pipeline strategy configurations
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @return []interface{}*/
-func (a *ApplicationControllerApiService) GetStrategyConfigsForApplicationUsingGET(ctx context.Context, application string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@return []interface{}*/
+func (a *ApplicationControllerApiService) GetStrategyConfigsForApplicationUsingGET(ctx context.Context, application string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -687,9 +674,8 @@ func (a *ApplicationControllerApiService) GetStrategyConfigsForApplicationUsingG
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -700,7 +686,7 @@ func (a *ApplicationControllerApiService) GetStrategyConfigsForApplicationUsingG
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -726,24 +712,23 @@ func (a *ApplicationControllerApiService) GetStrategyConfigsForApplicationUsingG
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Get task details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param taskDetailsId taskDetailsId
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return map[string]interface{}*/
-func (a *ApplicationControllerApiService) GetTaskDetailsUsingGET(ctx context.Context, id string, taskDetailsId string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param taskDetailsId taskDetailsId
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return map[string]interface{}*/
+func (a *ApplicationControllerApiService) GetTaskDetailsUsingGET(ctx context.Context, id string, taskDetailsId string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -760,7 +745,7 @@ func (a *ApplicationControllerApiService) GetTaskDetailsUsingGET(ctx context.Con
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -771,7 +756,7 @@ func (a *ApplicationControllerApiService) GetTaskDetailsUsingGET(ctx context.Con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -800,21 +785,20 @@ func (a *ApplicationControllerApiService) GetTaskDetailsUsingGET(ctx context.Con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Get task
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *ApplicationControllerApiService) GetTaskUsingGET(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *ApplicationControllerApiService) GetTaskUsingGET(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -825,9 +809,8 @@ func (a *ApplicationControllerApiService) GetTaskUsingGET(ctx context.Context, i
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -838,7 +821,7 @@ func (a *ApplicationControllerApiService) GetTaskUsingGET(ctx context.Context, i
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -864,25 +847,24 @@ func (a *ApplicationControllerApiService) GetTaskUsingGET(ctx context.Context, i
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Retrieve a list of an application&#39;s tasks
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "limit" (int32) limit
-     @param "page" (int32) page
-     @param "statuses" (string) statuses
- @return []interface{}*/
-func (a *ApplicationControllerApiService) GetTasksUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "limit" (int32) limit
+    @param "page" (int32) page
+    @param "statuses" (string) statuses
+@return []interface{}*/
+func (a *ApplicationControllerApiService) GetTasksUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -913,7 +895,7 @@ func (a *ApplicationControllerApiService) GetTasksUsingGET(ctx context.Context, 
 		localVarQueryParams.Add("statuses", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -924,7 +906,7 @@ func (a *ApplicationControllerApiService) GetTasksUsingGET(ctx context.Context, 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -950,25 +932,24 @@ func (a *ApplicationControllerApiService) GetTasksUsingGET(ctx context.Context, 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Invoke pipeline config
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param pipelineName pipelineName
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "trigger" (interface{}) trigger
-     @param "user" (string) user
- @return HttpEntity*/
-func (a *ApplicationControllerApiService) InvokePipelineConfigUsingPOST(ctx context.Context, application string, pipelineName string, localVarOptionals map[string]interface{}) (HttpEntity,  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param pipelineName pipelineName
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "trigger" (interface{}) trigger
+    @param "user" (string) user
+@return HttpEntity*/
+func (a *ApplicationControllerApiService) InvokePipelineConfigUsingPOST(ctx context.Context, application string, pipelineName string, localVarOptionals map[string]interface{}) (HttpEntity, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  HttpEntity
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     HttpEntity
 	)
 
 	// create path and map variables
@@ -988,7 +969,7 @@ func (a *ApplicationControllerApiService) InvokePipelineConfigUsingPOST(ctx cont
 		localVarQueryParams.Add("user", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -999,7 +980,7 @@ func (a *ApplicationControllerApiService) InvokePipelineConfigUsingPOST(ctx cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -1029,22 +1010,21 @@ func (a *ApplicationControllerApiService) InvokePipelineConfigUsingPOST(ctx cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ApplicationControllerApiService Create task
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param map_ map
- @return map[string]interface{}*/
-func (a *ApplicationControllerApiService) TaskUsingPOST(ctx context.Context, application string, map_ interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param map_ map
+@return map[string]interface{}*/
+func (a *ApplicationControllerApiService) TaskUsingPOST(ctx context.Context, application string, map_ interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -1055,9 +1035,8 @@ func (a *ApplicationControllerApiService) TaskUsingPOST(ctx context.Context, app
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -1068,7 +1047,7 @@ func (a *ApplicationControllerApiService) TaskUsingPOST(ctx context.Context, app
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -1096,7 +1075,5 @@ func (a *ApplicationControllerApiService) TaskUsingPOST(ctx context.Context, app
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/artifact_controller_api.go
+++ b/gateapi/artifact_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,19 +27,18 @@ var (
 
 type ArtifactControllerApiService service
 
-
 /* ArtifactControllerApiService Retrieve the list of artifact accounts configured in Clouddriver.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *ArtifactControllerApiService) AllUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *ArtifactControllerApiService) AllUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -53,7 +53,7 @@ func (a *ArtifactControllerApiService) AllUsingGET(ctx context.Context, localVar
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -64,7 +64,7 @@ func (a *ArtifactControllerApiService) AllUsingGET(ctx context.Context, localVar
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -93,25 +93,24 @@ func (a *ArtifactControllerApiService) AllUsingGET(ctx context.Context, localVar
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ArtifactControllerApiService Retrieve the list of artifact versions by account and artifact names
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param accountName accountName
- @param artifactName artifactName
- @param type_ type
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []string*/
-func (a *ArtifactControllerApiService) ArtifactVersionsUsingGET(ctx context.Context, accountName string, artifactName string, type_ string, localVarOptionals map[string]interface{}) ([]string,  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param accountName accountName
+@param artifactName artifactName
+@param type_ type
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []string*/
+func (a *ArtifactControllerApiService) ArtifactVersionsUsingGET(ctx context.Context, accountName string, artifactName string, type_ string, localVarOptionals map[string]interface{}) ([]string, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []string
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []string
 	)
 
 	// create path and map variables
@@ -129,7 +128,7 @@ func (a *ArtifactControllerApiService) ArtifactVersionsUsingGET(ctx context.Cont
 	localVarQueryParams.Add("artifactName", parameterToString(artifactName, ""))
 	localVarQueryParams.Add("type", parameterToString(type_, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -140,7 +139,7 @@ func (a *ArtifactControllerApiService) ArtifactVersionsUsingGET(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -169,23 +168,22 @@ func (a *ArtifactControllerApiService) ArtifactVersionsUsingGET(ctx context.Cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ArtifactControllerApiService Retrieve the specified artifact version for an artifact provider and package name
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param packageName packageName
- @param provider provider
- @param version version
- @return interface{}*/
-func (a *ArtifactControllerApiService) GetArtifactUsingGET(ctx context.Context, packageName string, provider string, version string) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param packageName packageName
+@param provider provider
+@param version version
+@return interface{}*/
+func (a *ArtifactControllerApiService) GetArtifactUsingGET(ctx context.Context, packageName string, provider string, version string) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -198,9 +196,8 @@ func (a *ArtifactControllerApiService) GetArtifactUsingGET(ctx context.Context, 
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -211,7 +208,7 @@ func (a *ArtifactControllerApiService) GetArtifactUsingGET(ctx context.Context, 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -237,7 +234,5 @@ func (a *ArtifactControllerApiService) GetArtifactUsingGET(ctx context.Context, 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/auth_controller_api.go
+++ b/gateapi/auth_controller_api.go
@@ -10,12 +10,13 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -25,17 +26,16 @@ var (
 
 type AuthControllerApiService service
 
-
 /* AuthControllerApiService Get service accounts
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *AuthControllerApiService) GetServiceAccountsUsingGET(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *AuthControllerApiService) GetServiceAccountsUsingGET(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -45,9 +45,8 @@ func (a *AuthControllerApiService) GetServiceAccountsUsingGET(ctx context.Contex
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -58,7 +57,7 @@ func (a *AuthControllerApiService) GetServiceAccountsUsingGET(ctx context.Contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -84,20 +83,19 @@ func (a *AuthControllerApiService) GetServiceAccountsUsingGET(ctx context.Contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* AuthControllerApiService Get logged out message
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return string*/
-func (a *AuthControllerApiService) LoggedOutUsingGET(ctx context.Context) (string,  *http.Response, error) {
+func (a *AuthControllerApiService) LoggedOutUsingGET(ctx context.Context) (string, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  string
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     string
 	)
 
 	// create path and map variables
@@ -107,9 +105,8 @@ func (a *AuthControllerApiService) LoggedOutUsingGET(ctx context.Context) (strin
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -120,7 +117,7 @@ func (a *AuthControllerApiService) LoggedOutUsingGET(ctx context.Context) (strin
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -146,20 +143,19 @@ func (a *AuthControllerApiService) LoggedOutUsingGET(ctx context.Context) (strin
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* AuthControllerApiService Redirect to Deck
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param to to
- @return */
-func (a *AuthControllerApiService) RedirectUsingGET(ctx context.Context, to string) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param to to
+@return */
+func (a *AuthControllerApiService) RedirectUsingGET(ctx context.Context, to string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -169,10 +165,9 @@ func (a *AuthControllerApiService) RedirectUsingGET(ctx context.Context, to stri
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	localVarQueryParams.Add("to", parameterToString(to, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -183,7 +178,7 @@ func (a *AuthControllerApiService) RedirectUsingGET(ctx context.Context, to stri
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -211,12 +206,12 @@ func (a *AuthControllerApiService) RedirectUsingGET(ctx context.Context, to stri
 /* AuthControllerApiService Sync user roles
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return */
-func (a *AuthControllerApiService) SyncUsingPOST(ctx context.Context) ( *http.Response, error) {
+func (a *AuthControllerApiService) SyncUsingPOST(ctx context.Context) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -226,9 +221,8 @@ func (a *AuthControllerApiService) SyncUsingPOST(ctx context.Context) ( *http.Re
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -239,7 +233,7 @@ func (a *AuthControllerApiService) SyncUsingPOST(ctx context.Context) ( *http.Re
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -267,13 +261,13 @@ func (a *AuthControllerApiService) SyncUsingPOST(ctx context.Context) ( *http.Re
 /* AuthControllerApiService Get user
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return User*/
-func (a *AuthControllerApiService) UserUsingGET(ctx context.Context) (User,  *http.Response, error) {
+func (a *AuthControllerApiService) UserUsingGET(ctx context.Context) (User, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  User
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     User
 	)
 
 	// create path and map variables
@@ -283,9 +277,8 @@ func (a *AuthControllerApiService) UserUsingGET(ctx context.Context) (User,  *ht
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -296,7 +289,7 @@ func (a *AuthControllerApiService) UserUsingGET(ctx context.Context) (User,  *ht
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -322,7 +315,5 @@ func (a *AuthControllerApiService) UserUsingGET(ctx context.Context) (User,  *ht
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/bake_controller_api.go
+++ b/gateapi/bake_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,18 +27,17 @@ var (
 
 type BakeControllerApiService service
 
-
 /* BakeControllerApiService Retrieve a list of available bakery base images for a given cloud provider
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param cloudProvider cloudProvider
- @return interface{}*/
-func (a *BakeControllerApiService) BakeOptionsUsingGET(ctx context.Context, cloudProvider string) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param cloudProvider cloudProvider
+@return interface{}*/
+func (a *BakeControllerApiService) BakeOptionsUsingGET(ctx context.Context, cloudProvider string) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -48,9 +48,8 @@ func (a *BakeControllerApiService) BakeOptionsUsingGET(ctx context.Context, clou
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -61,7 +60,7 @@ func (a *BakeControllerApiService) BakeOptionsUsingGET(ctx context.Context, clou
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -87,20 +86,19 @@ func (a *BakeControllerApiService) BakeOptionsUsingGET(ctx context.Context, clou
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BakeControllerApiService Retrieve a list of available bakery base images, grouped by cloud provider
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return interface{}*/
-func (a *BakeControllerApiService) BakeOptionsUsingGET1(ctx context.Context) (interface{},  *http.Response, error) {
+func (a *BakeControllerApiService) BakeOptionsUsingGET1(ctx context.Context) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -110,9 +108,8 @@ func (a *BakeControllerApiService) BakeOptionsUsingGET1(ctx context.Context) (in
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -123,7 +120,7 @@ func (a *BakeControllerApiService) BakeOptionsUsingGET1(ctx context.Context) (in
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -149,22 +146,21 @@ func (a *BakeControllerApiService) BakeOptionsUsingGET1(ctx context.Context) (in
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BakeControllerApiService Retrieve the logs for a given bake
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param region region
- @param statusId statusId
- @return interface{}*/
-func (a *BakeControllerApiService) LookupLogsUsingGET(ctx context.Context, region string, statusId string) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param region region
+@param statusId statusId
+@return interface{}*/
+func (a *BakeControllerApiService) LookupLogsUsingGET(ctx context.Context, region string, statusId string) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -176,9 +172,8 @@ func (a *BakeControllerApiService) LookupLogsUsingGET(ctx context.Context, regio
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -189,7 +184,7 @@ func (a *BakeControllerApiService) LookupLogsUsingGET(ctx context.Context, regio
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -215,7 +210,5 @@ func (a *BakeControllerApiService) LookupLogsUsingGET(ctx context.Context, regio
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/build_controller_api.go
+++ b/gateapi/build_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,20 +27,19 @@ var (
 
 type BuildControllerApiService service
 
-
 /* BuildControllerApiService Get build masters
- Deprecated, use the v3 endpoint instead
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "type_" (string) type
- @return []interface{}*/
-func (a *BuildControllerApiService) GetBuildMastersUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+Deprecated, use the v3 endpoint instead
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "type_" (string) type
+@return []interface{}*/
+func (a *BuildControllerApiService) GetBuildMastersUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -57,7 +57,7 @@ func (a *BuildControllerApiService) GetBuildMastersUsingGET(ctx context.Context,
 		localVarQueryParams.Add("type", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -68,7 +68,7 @@ func (a *BuildControllerApiService) GetBuildMastersUsingGET(ctx context.Context,
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -94,23 +94,22 @@ func (a *BuildControllerApiService) GetBuildMastersUsingGET(ctx context.Context,
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get build for build master
- Deprecated, use the v3 endpoint instead
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @param number number
- @return map[string]interface{}*/
-func (a *BuildControllerApiService) GetBuildUsingGET(ctx context.Context, buildMaster string, number string) (map[string]interface{},  *http.Response, error) {
+Deprecated, use the v3 endpoint instead
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@param number number
+@return map[string]interface{}*/
+func (a *BuildControllerApiService) GetBuildUsingGET(ctx context.Context, buildMaster string, number string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -122,9 +121,8 @@ func (a *BuildControllerApiService) GetBuildUsingGET(ctx context.Context, buildM
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -135,7 +133,7 @@ func (a *BuildControllerApiService) GetBuildUsingGET(ctx context.Context, buildM
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -161,22 +159,21 @@ func (a *BuildControllerApiService) GetBuildUsingGET(ctx context.Context, buildM
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get builds for build master
- Deprecated, use the v3 endpoint instead
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @return []interface{}*/
-func (a *BuildControllerApiService) GetBuildsUsingGET(ctx context.Context, buildMaster string) ([]interface{},  *http.Response, error) {
+Deprecated, use the v3 endpoint instead
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@return []interface{}*/
+func (a *BuildControllerApiService) GetBuildsUsingGET(ctx context.Context, buildMaster string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -187,9 +184,8 @@ func (a *BuildControllerApiService) GetBuildsUsingGET(ctx context.Context, build
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -200,7 +196,7 @@ func (a *BuildControllerApiService) GetBuildsUsingGET(ctx context.Context, build
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -226,22 +222,21 @@ func (a *BuildControllerApiService) GetBuildsUsingGET(ctx context.Context, build
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get job config
- Deprecated, use the v3 endpoint instead
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @return map[string]interface{}*/
-func (a *BuildControllerApiService) GetJobConfigUsingGET(ctx context.Context, buildMaster string) (map[string]interface{},  *http.Response, error) {
+Deprecated, use the v3 endpoint instead
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@return map[string]interface{}*/
+func (a *BuildControllerApiService) GetJobConfigUsingGET(ctx context.Context, buildMaster string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -252,9 +247,8 @@ func (a *BuildControllerApiService) GetJobConfigUsingGET(ctx context.Context, bu
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -265,7 +259,7 @@ func (a *BuildControllerApiService) GetJobConfigUsingGET(ctx context.Context, bu
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -291,22 +285,21 @@ func (a *BuildControllerApiService) GetJobConfigUsingGET(ctx context.Context, bu
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get jobs for build master
- Deprecated, use the v3 endpoint instead
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @return []interface{}*/
-func (a *BuildControllerApiService) GetJobsForBuildMasterUsingGET(ctx context.Context, buildMaster string) ([]interface{},  *http.Response, error) {
+Deprecated, use the v3 endpoint instead
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@return []interface{}*/
+func (a *BuildControllerApiService) GetJobsForBuildMasterUsingGET(ctx context.Context, buildMaster string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -317,9 +310,8 @@ func (a *BuildControllerApiService) GetJobsForBuildMasterUsingGET(ctx context.Co
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -330,7 +322,7 @@ func (a *BuildControllerApiService) GetJobsForBuildMasterUsingGET(ctx context.Co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -356,22 +348,21 @@ func (a *BuildControllerApiService) GetJobsForBuildMasterUsingGET(ctx context.Co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get build masters
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "type_" (string) type
- @return []interface{}*/
-func (a *BuildControllerApiService) V3GetBuildMastersUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "type_" (string) type
+@return []interface{}*/
+func (a *BuildControllerApiService) V3GetBuildMastersUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -389,7 +380,7 @@ func (a *BuildControllerApiService) V3GetBuildMastersUsingGET(ctx context.Contex
 		localVarQueryParams.Add("type", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -400,7 +391,7 @@ func (a *BuildControllerApiService) V3GetBuildMastersUsingGET(ctx context.Contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -426,23 +417,22 @@ func (a *BuildControllerApiService) V3GetBuildMastersUsingGET(ctx context.Contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get build for build master
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @param job job
- @param number number
- @return map[string]interface{}*/
-func (a *BuildControllerApiService) V3GetBuildUsingGET(ctx context.Context, buildMaster string, job string, number string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@param job job
+@param number number
+@return map[string]interface{}*/
+func (a *BuildControllerApiService) V3GetBuildUsingGET(ctx context.Context, buildMaster string, job string, number string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -454,10 +444,9 @@ func (a *BuildControllerApiService) V3GetBuildUsingGET(ctx context.Context, buil
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	localVarQueryParams.Add("job", parameterToString(job, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -468,7 +457,7 @@ func (a *BuildControllerApiService) V3GetBuildUsingGET(ctx context.Context, buil
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -494,22 +483,21 @@ func (a *BuildControllerApiService) V3GetBuildUsingGET(ctx context.Context, buil
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get builds for build master
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @param job job
- @return []interface{}*/
-func (a *BuildControllerApiService) V3GetBuildsUsingGET(ctx context.Context, buildMaster string, job string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@param job job
+@return []interface{}*/
+func (a *BuildControllerApiService) V3GetBuildsUsingGET(ctx context.Context, buildMaster string, job string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -520,10 +508,9 @@ func (a *BuildControllerApiService) V3GetBuildsUsingGET(ctx context.Context, bui
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	localVarQueryParams.Add("job", parameterToString(job, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -534,7 +521,7 @@ func (a *BuildControllerApiService) V3GetBuildsUsingGET(ctx context.Context, bui
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -560,22 +547,21 @@ func (a *BuildControllerApiService) V3GetBuildsUsingGET(ctx context.Context, bui
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get job config
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @param job job
- @return map[string]interface{}*/
-func (a *BuildControllerApiService) V3GetJobConfigUsingGET(ctx context.Context, buildMaster string, job string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@param job job
+@return map[string]interface{}*/
+func (a *BuildControllerApiService) V3GetJobConfigUsingGET(ctx context.Context, buildMaster string, job string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -586,10 +572,9 @@ func (a *BuildControllerApiService) V3GetJobConfigUsingGET(ctx context.Context, 
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	localVarQueryParams.Add("job", parameterToString(job, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -600,7 +585,7 @@ func (a *BuildControllerApiService) V3GetJobConfigUsingGET(ctx context.Context, 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -626,21 +611,20 @@ func (a *BuildControllerApiService) V3GetJobConfigUsingGET(ctx context.Context, 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* BuildControllerApiService Get jobs for build master
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @return []interface{}*/
-func (a *BuildControllerApiService) V3GetJobsForBuildMasterUsingGET(ctx context.Context, buildMaster string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@return []interface{}*/
+func (a *BuildControllerApiService) V3GetJobsForBuildMasterUsingGET(ctx context.Context, buildMaster string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -651,9 +635,8 @@ func (a *BuildControllerApiService) V3GetJobsForBuildMasterUsingGET(ctx context.
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -664,7 +647,7 @@ func (a *BuildControllerApiService) V3GetJobsForBuildMasterUsingGET(ctx context.
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -690,7 +673,5 @@ func (a *BuildControllerApiService) V3GetJobsForBuildMasterUsingGET(ctx context.
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/cluster_controller_api.go
+++ b/gateapi/cluster_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,23 +27,22 @@ var (
 
 type ClusterControllerApiService service
 
-
 /* ClusterControllerApiService Retrieve a cluster&#39;s loadbalancers
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param applicationName applicationName
- @param clusterName clusterName
- @param type_ type
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *ClusterControllerApiService) GetClusterLoadBalancersUsingGET(ctx context.Context, account string, applicationName string, clusterName string, type_ string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param applicationName applicationName
+@param clusterName clusterName
+@param type_ type
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *ClusterControllerApiService) GetClusterLoadBalancersUsingGET(ctx context.Context, account string, applicationName string, clusterName string, type_ string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -61,7 +61,7 @@ func (a *ClusterControllerApiService) GetClusterLoadBalancersUsingGET(ctx contex
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -72,7 +72,7 @@ func (a *ClusterControllerApiService) GetClusterLoadBalancersUsingGET(ctx contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -101,25 +101,24 @@ func (a *ClusterControllerApiService) GetClusterLoadBalancersUsingGET(ctx contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ClusterControllerApiService Retrieve a cluster&#39;s details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @param clusterName clusterName
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return map[string]interface{}*/
-func (a *ClusterControllerApiService) GetClustersUsingGET(ctx context.Context, account string, application string, clusterName string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@param clusterName clusterName
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return map[string]interface{}*/
+func (a *ClusterControllerApiService) GetClustersUsingGET(ctx context.Context, account string, application string, clusterName string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -137,7 +136,7 @@ func (a *ClusterControllerApiService) GetClustersUsingGET(ctx context.Context, a
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -148,7 +147,7 @@ func (a *ClusterControllerApiService) GetClustersUsingGET(ctx context.Context, a
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -177,24 +176,23 @@ func (a *ClusterControllerApiService) GetClustersUsingGET(ctx context.Context, a
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ClusterControllerApiService Retrieve a list of clusters for an account
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *ClusterControllerApiService) GetClustersUsingGET1(ctx context.Context, account string, application string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *ClusterControllerApiService) GetClustersUsingGET1(ctx context.Context, account string, application string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -211,7 +209,7 @@ func (a *ClusterControllerApiService) GetClustersUsingGET1(ctx context.Context, 
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -222,7 +220,7 @@ func (a *ClusterControllerApiService) GetClustersUsingGET1(ctx context.Context, 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -251,23 +249,22 @@ func (a *ClusterControllerApiService) GetClustersUsingGET1(ctx context.Context, 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ClusterControllerApiService Retrieve a list of cluster names for an application, grouped by account
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return map[string]interface{}*/
-func (a *ClusterControllerApiService) GetClustersUsingGET2(ctx context.Context, application string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return map[string]interface{}*/
+func (a *ClusterControllerApiService) GetClustersUsingGET2(ctx context.Context, application string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -283,7 +280,7 @@ func (a *ClusterControllerApiService) GetClustersUsingGET2(ctx context.Context, 
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -294,7 +291,7 @@ func (a *ClusterControllerApiService) GetClustersUsingGET2(ctx context.Context, 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -323,28 +320,27 @@ func (a *ClusterControllerApiService) GetClustersUsingGET2(ctx context.Context, 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ClusterControllerApiService Retrieve a list of scaling activities for a server group
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @param clusterName clusterName
- @param serverGroupName serverGroupName
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
-     @param "region" (string) region
- @return []interface{}*/
-func (a *ClusterControllerApiService) GetScalingActivitiesUsingGET(ctx context.Context, account string, application string, clusterName string, serverGroupName string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@param clusterName clusterName
+@param serverGroupName serverGroupName
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+    @param "region" (string) region
+@return []interface{}*/
+func (a *ClusterControllerApiService) GetScalingActivitiesUsingGET(ctx context.Context, account string, application string, clusterName string, serverGroupName string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -375,7 +371,7 @@ func (a *ClusterControllerApiService) GetScalingActivitiesUsingGET(ctx context.C
 		localVarQueryParams.Add("region", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -386,7 +382,7 @@ func (a *ClusterControllerApiService) GetScalingActivitiesUsingGET(ctx context.C
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -415,26 +411,25 @@ func (a *ClusterControllerApiService) GetScalingActivitiesUsingGET(ctx context.C
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ClusterControllerApiService Retrieve a server group&#39;s details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @param clusterName clusterName
- @param serverGroupName serverGroupName
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *ClusterControllerApiService) GetServerGroupsUsingGET(ctx context.Context, account string, application string, clusterName string, serverGroupName string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@param clusterName clusterName
+@param serverGroupName serverGroupName
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *ClusterControllerApiService) GetServerGroupsUsingGET(ctx context.Context, account string, application string, clusterName string, serverGroupName string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -453,7 +448,7 @@ func (a *ClusterControllerApiService) GetServerGroupsUsingGET(ctx context.Contex
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -464,7 +459,7 @@ func (a *ClusterControllerApiService) GetServerGroupsUsingGET(ctx context.Contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -493,25 +488,24 @@ func (a *ClusterControllerApiService) GetServerGroupsUsingGET(ctx context.Contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ClusterControllerApiService Retrieve a list of server groups for a cluster
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @param clusterName clusterName
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *ClusterControllerApiService) GetServerGroupsUsingGET1(ctx context.Context, account string, application string, clusterName string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@param clusterName clusterName
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *ClusterControllerApiService) GetServerGroupsUsingGET1(ctx context.Context, account string, application string, clusterName string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -529,7 +523,7 @@ func (a *ClusterControllerApiService) GetServerGroupsUsingGET1(ctx context.Conte
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -540,7 +534,7 @@ func (a *ClusterControllerApiService) GetServerGroupsUsingGET1(ctx context.Conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -569,31 +563,30 @@ func (a *ClusterControllerApiService) GetServerGroupsUsingGET1(ctx context.Conte
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ClusterControllerApiService Retrieve a server group that matches a target coordinate (e.g., newest, ancestor) relative to a cluster
- &#x60;scope&#x60; is either a zone or a region
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @param cloudProvider cloudProvider
- @param clusterName clusterName
- @param scope scope
- @param target target
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "onlyEnabled" (bool) onlyEnabled
-     @param "validateOldest" (bool) validateOldest
- @return map[string]interface{}*/
-func (a *ClusterControllerApiService) GetTargetServerGroupUsingGET(ctx context.Context, account string, application string, cloudProvider string, clusterName string, scope string, target string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+&#x60;scope&#x60; is either a zone or a region
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@param cloudProvider cloudProvider
+@param clusterName clusterName
+@param scope scope
+@param target target
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "onlyEnabled" (bool) onlyEnabled
+    @param "validateOldest" (bool) validateOldest
+@return map[string]interface{}*/
+func (a *ClusterControllerApiService) GetTargetServerGroupUsingGET(ctx context.Context, account string, application string, cloudProvider string, clusterName string, scope string, target string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -626,7 +619,7 @@ func (a *ClusterControllerApiService) GetTargetServerGroupUsingGET(ctx context.C
 		localVarQueryParams.Add("validateOldest", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -637,7 +630,7 @@ func (a *ClusterControllerApiService) GetTargetServerGroupUsingGET(ctx context.C
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -666,7 +659,5 @@ func (a *ClusterControllerApiService) GetTargetServerGroupUsingGET(ctx context.C
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/concourse_controller_api.go
+++ b/gateapi/concourse_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,20 +27,19 @@ var (
 
 type ConcourseControllerApiService service
 
-
 /* ConcourseControllerApiService Retrieve the list of job names for a given pipeline available to triggers
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @param pipeline pipeline
- @param team team
- @return []interface{}*/
-func (a *ConcourseControllerApiService) JobsUsingGET(ctx context.Context, buildMaster string, pipeline string, team string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@param pipeline pipeline
+@param team team
+@return []interface{}*/
+func (a *ConcourseControllerApiService) JobsUsingGET(ctx context.Context, buildMaster string, pipeline string, team string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -52,9 +52,8 @@ func (a *ConcourseControllerApiService) JobsUsingGET(ctx context.Context, buildM
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -65,7 +64,7 @@ func (a *ConcourseControllerApiService) JobsUsingGET(ctx context.Context, buildM
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -91,22 +90,21 @@ func (a *ConcourseControllerApiService) JobsUsingGET(ctx context.Context, buildM
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ConcourseControllerApiService Retrieve the list of pipeline names for a given team available to triggers
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @param team team
- @return []interface{}*/
-func (a *ConcourseControllerApiService) PipelinesUsingGET(ctx context.Context, buildMaster string, team string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@param team team
+@return []interface{}*/
+func (a *ConcourseControllerApiService) PipelinesUsingGET(ctx context.Context, buildMaster string, team string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -118,9 +116,8 @@ func (a *ConcourseControllerApiService) PipelinesUsingGET(ctx context.Context, b
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -131,7 +128,7 @@ func (a *ConcourseControllerApiService) PipelinesUsingGET(ctx context.Context, b
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -157,23 +154,22 @@ func (a *ConcourseControllerApiService) PipelinesUsingGET(ctx context.Context, b
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ConcourseControllerApiService Retrieve the list of resource names for a given pipeline available to the Concourse stage
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param buildMaster buildMaster
- @param pipeline pipeline
- @param team team
- @return []interface{}*/
-func (a *ConcourseControllerApiService) ResourcesUsingGET(ctx context.Context, buildMaster string, pipeline string, team string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param buildMaster buildMaster
+@param pipeline pipeline
+@param team team
+@return []interface{}*/
+func (a *ConcourseControllerApiService) ResourcesUsingGET(ctx context.Context, buildMaster string, pipeline string, team string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -186,9 +182,8 @@ func (a *ConcourseControllerApiService) ResourcesUsingGET(ctx context.Context, b
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -199,7 +194,7 @@ func (a *ConcourseControllerApiService) ResourcesUsingGET(ctx context.Context, b
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -225,7 +220,5 @@ func (a *ConcourseControllerApiService) ResourcesUsingGET(ctx context.Context, b
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/configuration.go
+++ b/gateapi/configuration.go
@@ -25,37 +25,37 @@ func (c contextKey) String() string {
 
 var (
 	// ContextOAuth2 takes a oauth2.TokenSource as authentication for the request.
-	ContextOAuth2    	= contextKey("token")
+	ContextOAuth2 = contextKey("token")
 
 	// ContextBasicAuth takes BasicAuth as authentication for the request.
-	ContextBasicAuth 	= contextKey("basic")
+	ContextBasicAuth = contextKey("basic")
 
 	// ContextAccessToken takes a string oauth2 access token as authentication for the request.
-	ContextAccessToken 	= contextKey("accesstoken")
+	ContextAccessToken = contextKey("accesstoken")
 
 	// ContextAPIKey takes an APIKey as authentication for the request
- 	ContextAPIKey 		= contextKey("apikey")
+	ContextAPIKey = contextKey("apikey")
 )
 
-// BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth 
+// BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth
 type BasicAuth struct {
-	UserName      string            `json:"userName,omitempty"`
-	Password      string            `json:"password,omitempty"`	
+	UserName string `json:"userName,omitempty"`
+	Password string `json:"password,omitempty"`
 }
 
 // APIKey provides API key based authentication to a request passed via context using ContextAPIKey
 type APIKey struct {
-	Key 	string
-	Prefix	string
+	Key    string
+	Prefix string
 }
 
 type Configuration struct {
-	BasePath      string            	`json:"basePath,omitempty"`
-	Host          string            	`json:"host,omitempty"`
-	Scheme        string            	`json:"scheme,omitempty"`
-	DefaultHeader map[string]string 	`json:"defaultHeader,omitempty"`
-	UserAgent     string            	`json:"userAgent,omitempty"`
-	HTTPClient 	  *http.Client
+	BasePath      string            `json:"basePath,omitempty"`
+	Host          string            `json:"host,omitempty"`
+	Scheme        string            `json:"scheme,omitempty"`
+	DefaultHeader map[string]string `json:"defaultHeader,omitempty"`
+	UserAgent     string            `json:"userAgent,omitempty"`
+	HTTPClient    *http.Client
 }
 
 func NewConfiguration() *Configuration {

--- a/gateapi/credentials_controller_api.go
+++ b/gateapi/credentials_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,32 +27,31 @@ var (
 
 type CredentialsControllerApiService service
 
-
 /* CredentialsControllerApiService Retrieve an account&#39;s details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "accountNonExpired" (bool) 
-     @param "accountNonLocked" (bool) 
-     @param "allowedAccounts" ([]string) 
-     @param "authorities0Authority" (string) 
-     @param "credentialsNonExpired" (bool) 
-     @param "email" (string) 
-     @param "enabled" (bool) 
-     @param "firstName" (string) 
-     @param "lastName" (string) 
-     @param "password" (string) 
-     @param "roles" ([]string) 
-     @param "username" (string) 
- @return AccountDetails*/
-func (a *CredentialsControllerApiService) GetAccountUsingGET(ctx context.Context, account string, localVarOptionals map[string]interface{}) (AccountDetails,  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "accountNonExpired" (bool)
+    @param "accountNonLocked" (bool)
+    @param "allowedAccounts" ([]string)
+    @param "authorities0Authority" (string)
+    @param "credentialsNonExpired" (bool)
+    @param "email" (string)
+    @param "enabled" (bool)
+    @param "firstName" (string)
+    @param "lastName" (string)
+    @param "password" (string)
+    @param "roles" ([]string)
+    @param "username" (string)
+@return AccountDetails*/
+func (a *CredentialsControllerApiService) GetAccountUsingGET(ctx context.Context, account string, localVarOptionals map[string]interface{}) (AccountDetails, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  AccountDetails
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     AccountDetails
 	)
 
 	// create path and map variables
@@ -133,7 +133,7 @@ func (a *CredentialsControllerApiService) GetAccountUsingGET(ctx context.Context
 		localVarQueryParams.Add("username", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -144,7 +144,7 @@ func (a *CredentialsControllerApiService) GetAccountUsingGET(ctx context.Context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -173,34 +173,33 @@ func (a *CredentialsControllerApiService) GetAccountUsingGET(ctx context.Context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* CredentialsControllerApiService Retrieve a list of accounts
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "accountNonExpired" (bool) 
-     @param "accountNonLocked" (bool) 
-     @param "allowedAccounts" ([]string) 
-     @param "authorities0Authority" (string) 
-     @param "credentialsNonExpired" (bool) 
-     @param "email" (string) 
-     @param "enabled" (bool) 
-     @param "expand" (bool) expand
-     @param "firstName" (string) 
-     @param "lastName" (string) 
-     @param "password" (string) 
-     @param "roles" ([]string) 
-     @param "username" (string) 
- @return []Account*/
-func (a *CredentialsControllerApiService) GetAccountsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]Account,  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "accountNonExpired" (bool)
+    @param "accountNonLocked" (bool)
+    @param "allowedAccounts" ([]string)
+    @param "authorities0Authority" (string)
+    @param "credentialsNonExpired" (bool)
+    @param "email" (string)
+    @param "enabled" (bool)
+    @param "expand" (bool) expand
+    @param "firstName" (string)
+    @param "lastName" (string)
+    @param "password" (string)
+    @param "roles" ([]string)
+    @param "username" (string)
+@return []Account*/
+func (a *CredentialsControllerApiService) GetAccountsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]Account, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []Account
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []Account
 	)
 
 	// create path and map variables
@@ -284,7 +283,7 @@ func (a *CredentialsControllerApiService) GetAccountsUsingGET(ctx context.Contex
 		localVarQueryParams.Add("username", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -295,7 +294,7 @@ func (a *CredentialsControllerApiService) GetAccountsUsingGET(ctx context.Contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -321,7 +320,5 @@ func (a *CredentialsControllerApiService) GetAccountsUsingGET(ctx context.Contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/ecs_server_group_events_controller_api.go
+++ b/gateapi/ecs_server_group_events_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,22 +27,21 @@ var (
 
 type EcsServerGroupEventsControllerApiService service
 
-
 /* EcsServerGroupEventsControllerApiService Retrieves a list of events for a server group
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @param provider provider
- @param region region
- @param serverGroupName serverGroupName
- @return []interface{}*/
-func (a *EcsServerGroupEventsControllerApiService) GetEventsUsingGET(ctx context.Context, account string, application string, provider string, region string, serverGroupName string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@param provider provider
+@param region region
+@param serverGroupName serverGroupName
+@return []interface{}*/
+func (a *EcsServerGroupEventsControllerApiService) GetEventsUsingGET(ctx context.Context, account string, application string, provider string, region string, serverGroupName string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -54,11 +54,10 @@ func (a *EcsServerGroupEventsControllerApiService) GetEventsUsingGET(ctx context
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	localVarQueryParams.Add("provider", parameterToString(provider, ""))
 	localVarQueryParams.Add("region", parameterToString(region, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -69,7 +68,7 @@ func (a *EcsServerGroupEventsControllerApiService) GetEventsUsingGET(ctx context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -95,7 +94,5 @@ func (a *EcsServerGroupEventsControllerApiService) GetEventsUsingGET(ctx context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/executions_controller_api.go
+++ b/gateapi/executions_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,23 +27,22 @@ var (
 
 type ExecutionsControllerApiService service
 
-
 /* ExecutionsControllerApiService Retrieves an ad-hoc collection of executions based on a number of user-supplied parameters. Either executionIds or pipelineConfigIds must be supplied in order to return any results. If both are supplied, an exception will be thrown.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "executionIds" (string) A comma-separated list of executions to retrieve. Either this OR pipelineConfigIds must be supplied, but not both.
-     @param "expand" (bool) Expands each execution object in the resulting list. If this value is missing, it is defaulted to true.
-     @param "limit" (int32) The number of executions to return per pipeline configuration. Ignored if executionIds parameter is supplied. If this value is missing, it is defaulted to 1.
-     @param "pipelineConfigIds" (string) A comma-separated list of pipeline configuration IDs to retrieve recent executions for. Either this OR pipelineConfigIds must be supplied, but not both.
-     @param "statuses" (string) A comma-separated list of execution statuses to filter by. Ignored if executionIds parameter is supplied. If this value is missing, it is defaulted to all statuses.
- @return []interface{}*/
-func (a *ExecutionsControllerApiService) GetLatestExecutionsByConfigIdsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "executionIds" (string) A comma-separated list of executions to retrieve. Either this OR pipelineConfigIds must be supplied, but not both.
+    @param "expand" (bool) Expands each execution object in the resulting list. If this value is missing, it is defaulted to true.
+    @param "limit" (int32) The number of executions to return per pipeline configuration. Ignored if executionIds parameter is supplied. If this value is missing, it is defaulted to 1.
+    @param "pipelineConfigIds" (string) A comma-separated list of pipeline configuration IDs to retrieve recent executions for. Either this OR pipelineConfigIds must be supplied, but not both.
+    @param "statuses" (string) A comma-separated list of execution statuses to filter by. Ignored if executionIds parameter is supplied. If this value is missing, it is defaulted to all statuses.
+@return []interface{}*/
+func (a *ExecutionsControllerApiService) GetLatestExecutionsByConfigIdsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -84,7 +84,7 @@ func (a *ExecutionsControllerApiService) GetLatestExecutionsByConfigIdsUsingGET(
 		localVarQueryParams.Add("statuses", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -95,7 +95,7 @@ func (a *ExecutionsControllerApiService) GetLatestExecutionsByConfigIdsUsingGET(
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -121,33 +121,32 @@ func (a *ExecutionsControllerApiService) GetLatestExecutionsByConfigIdsUsingGET(
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ExecutionsControllerApiService Search for pipeline executions using a combination of criteria. The returned list is sorted by buildTime (trigger time) in reverse order so that newer executions are first in the list.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application Only includes executions that are part of this application. If this value is \&quot;*\&quot;, results will include executions of all applications.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "eventId" (string) Only includes executions that were triggered by a trigger with this eventId.
-     @param "expand" (bool) Expands each execution object in the resulting list. If this value is missing, it is defaulted to false.
-     @param "pipelineName" (string) Only includes executions that with this pipeline name.
-     @param "reverse" (bool) Reverses the resulting list before it is paginated. If this value is missing, it is defaulted to false.
-     @param "size" (int32) Sets the size of the resulting list for pagination. This value must be &gt; 0. If this value is missing, it is defaulted to 10.
-     @param "startIndex" (int32) Sets the first item of the resulting list for pagination. The list is 0-indexed. This value must be &gt;&#x3D; 0. If this value is missing, it is defaulted to 0.
-     @param "statuses" (string) Only includes executions with a status that is equal to a status provided in this field. The list of statuses should be given as a comma-delimited string. If this value is missing, includes executions of all statuses. Allowed statuses are: NOT_STARTED, RUNNING, PAUSED, SUSPENDED, SUCCEEDED, FAILED_CONTINUE, TERMINAL, CANCELED, REDIRECT, STOPPED, SKIPPED, BUFFERED.
-     @param "trigger" (string) Only includes executions that were triggered by a trigger that matches the subset of fields provided by this value. This value should be a base64-encoded string of a JSON representation of a trigger object. The comparison succeeds if the execution trigger contains all the fields of the input trigger, the fields are of the same type, and each value of the field \&quot;matches\&quot;. The term \&quot;matches\&quot; is specific for each field&#39;s type: - For Strings: A String value in the execution&#39;s trigger matches the input trigger&#39;s String value if the former equals the latter (case-insensitive) OR if the former matches the latter as a regular expression. - For Maps: A Map value in the execution&#39;s trigger matches the input trigger&#39;s Map value if the former contains all keys of the latter and their values match. - For Collections: A Collection value in the execution&#39;s trigger matches the input trigger&#39;s Collection value if the former has a unique element that matches each element of the latter. - Every other value is compared using the Java \&quot;equals\&quot; method (Groovy \&quot;&#x3D;&#x3D;\&quot; operator)
-     @param "triggerTimeEndBoundary" (int64) Only includes executions that were built at or before the given time, represented as a Unix timestamp in ms (UTC). This value must be &lt;&#x3D; 9223372036854775807 (Long.MAX_VALUE) and &gt;&#x3D; the value of [triggerTimeStartBoundary], if provided. If this value is missing, it is defaulted to 9223372036854775807.
-     @param "triggerTimeStartBoundary" (int64) Only includes executions that were built at or after the given time, represented as a Unix timestamp in ms (UTC). This value must be &gt;&#x3D; 0 and &lt;&#x3D; the value of [triggerTimeEndBoundary], if provided. If this value is missing, it is defaulted to 0.
-     @param "triggerTypes" (string) Only includes executions that were triggered by a trigger with a type that is equal to a type provided in this field. The list of trigger types should be a comma-delimited string. If this value is missing, results will includes executions of all trigger types.
- @return []interface{}*/
-func (a *ExecutionsControllerApiService) SearchForPipelineExecutionsByTriggerUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application Only includes executions that are part of this application. If this value is \&quot;*\&quot;, results will include executions of all applications.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "eventId" (string) Only includes executions that were triggered by a trigger with this eventId.
+    @param "expand" (bool) Expands each execution object in the resulting list. If this value is missing, it is defaulted to false.
+    @param "pipelineName" (string) Only includes executions that with this pipeline name.
+    @param "reverse" (bool) Reverses the resulting list before it is paginated. If this value is missing, it is defaulted to false.
+    @param "size" (int32) Sets the size of the resulting list for pagination. This value must be &gt; 0. If this value is missing, it is defaulted to 10.
+    @param "startIndex" (int32) Sets the first item of the resulting list for pagination. The list is 0-indexed. This value must be &gt;&#x3D; 0. If this value is missing, it is defaulted to 0.
+    @param "statuses" (string) Only includes executions with a status that is equal to a status provided in this field. The list of statuses should be given as a comma-delimited string. If this value is missing, includes executions of all statuses. Allowed statuses are: NOT_STARTED, RUNNING, PAUSED, SUSPENDED, SUCCEEDED, FAILED_CONTINUE, TERMINAL, CANCELED, REDIRECT, STOPPED, SKIPPED, BUFFERED.
+    @param "trigger" (string) Only includes executions that were triggered by a trigger that matches the subset of fields provided by this value. This value should be a base64-encoded string of a JSON representation of a trigger object. The comparison succeeds if the execution trigger contains all the fields of the input trigger, the fields are of the same type, and each value of the field \&quot;matches\&quot;. The term \&quot;matches\&quot; is specific for each field&#39;s type: - For Strings: A String value in the execution&#39;s trigger matches the input trigger&#39;s String value if the former equals the latter (case-insensitive) OR if the former matches the latter as a regular expression. - For Maps: A Map value in the execution&#39;s trigger matches the input trigger&#39;s Map value if the former contains all keys of the latter and their values match. - For Collections: A Collection value in the execution&#39;s trigger matches the input trigger&#39;s Collection value if the former has a unique element that matches each element of the latter. - Every other value is compared using the Java \&quot;equals\&quot; method (Groovy \&quot;&#x3D;&#x3D;\&quot; operator)
+    @param "triggerTimeEndBoundary" (int64) Only includes executions that were built at or before the given time, represented as a Unix timestamp in ms (UTC). This value must be &lt;&#x3D; 9223372036854775807 (Long.MAX_VALUE) and &gt;&#x3D; the value of [triggerTimeStartBoundary], if provided. If this value is missing, it is defaulted to 9223372036854775807.
+    @param "triggerTimeStartBoundary" (int64) Only includes executions that were built at or after the given time, represented as a Unix timestamp in ms (UTC). This value must be &gt;&#x3D; 0 and &lt;&#x3D; the value of [triggerTimeEndBoundary], if provided. If this value is missing, it is defaulted to 0.
+    @param "triggerTypes" (string) Only includes executions that were triggered by a trigger with a type that is equal to a type provided in this field. The list of trigger types should be a comma-delimited string. If this value is missing, results will includes executions of all trigger types.
+@return []interface{}*/
+func (a *ExecutionsControllerApiService) SearchForPipelineExecutionsByTriggerUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -226,7 +225,7 @@ func (a *ExecutionsControllerApiService) SearchForPipelineExecutionsByTriggerUsi
 		localVarQueryParams.Add("triggerTypes", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -237,7 +236,7 @@ func (a *ExecutionsControllerApiService) SearchForPipelineExecutionsByTriggerUsi
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -263,7 +262,5 @@ func (a *ExecutionsControllerApiService) SearchForPipelineExecutionsByTriggerUsi
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/firewall_controller_api.go
+++ b/gateapi/firewall_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,22 +27,21 @@ var (
 
 type FirewallControllerApiService service
 
-
 /* FirewallControllerApiService Retrieve a list of firewalls for a given account and region
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param region region
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return []interface{}*/
-func (a *FirewallControllerApiService) AllByAccountAndRegionUsingGET(ctx context.Context, account string, region string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param region region
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return []interface{}*/
+func (a *FirewallControllerApiService) AllByAccountAndRegionUsingGET(ctx context.Context, account string, region string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -64,7 +64,7 @@ func (a *FirewallControllerApiService) AllByAccountAndRegionUsingGET(ctx context
 		localVarQueryParams.Add("provider", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -75,7 +75,7 @@ func (a *FirewallControllerApiService) AllByAccountAndRegionUsingGET(ctx context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -104,24 +104,23 @@ func (a *FirewallControllerApiService) AllByAccountAndRegionUsingGET(ctx context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* FirewallControllerApiService Retrieve a list of firewalls for a given account, grouped by region
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return interface{}*/
-func (a *FirewallControllerApiService) AllByAccountUsingGET(ctx context.Context, account string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return interface{}*/
+func (a *FirewallControllerApiService) AllByAccountUsingGET(ctx context.Context, account string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -143,7 +142,7 @@ func (a *FirewallControllerApiService) AllByAccountUsingGET(ctx context.Context,
 		localVarQueryParams.Add("provider", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -154,7 +153,7 @@ func (a *FirewallControllerApiService) AllByAccountUsingGET(ctx context.Context,
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -183,23 +182,22 @@ func (a *FirewallControllerApiService) AllByAccountUsingGET(ctx context.Context,
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* FirewallControllerApiService Retrieve a list of firewalls, grouped by account, cloud provider, and region
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "id" (string) id
- @return interface{}*/
-func (a *FirewallControllerApiService) AllUsingGET1(ctx context.Context, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "id" (string) id
+@return interface{}*/
+func (a *FirewallControllerApiService) AllUsingGET1(ctx context.Context, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -220,7 +218,7 @@ func (a *FirewallControllerApiService) AllUsingGET1(ctx context.Context, localVa
 		localVarQueryParams.Add("id", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -231,7 +229,7 @@ func (a *FirewallControllerApiService) AllUsingGET1(ctx context.Context, localVa
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -260,27 +258,26 @@ func (a *FirewallControllerApiService) AllUsingGET1(ctx context.Context, localVa
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* FirewallControllerApiService Retrieve a firewall&#39;s details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param name name
- @param region region
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
-     @param "vpcId" (string) vpcId
- @return interface{}*/
-func (a *FirewallControllerApiService) GetSecurityGroupUsingGET(ctx context.Context, account string, name string, region string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param name name
+@param region region
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+    @param "vpcId" (string) vpcId
+@return interface{}*/
+func (a *FirewallControllerApiService) GetSecurityGroupUsingGET(ctx context.Context, account string, name string, region string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -310,7 +307,7 @@ func (a *FirewallControllerApiService) GetSecurityGroupUsingGET(ctx context.Cont
 		localVarQueryParams.Add("vpcId", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -321,7 +318,7 @@ func (a *FirewallControllerApiService) GetSecurityGroupUsingGET(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -350,7 +347,5 @@ func (a *FirewallControllerApiService) GetSecurityGroupUsingGET(ctx context.Cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/granted_authority.go
+++ b/gateapi/granted_authority.go
@@ -10,6 +10,5 @@
 package swagger
 
 type GrantedAuthority struct {
-
 	Authority string `json:"authority,omitempty"`
 }

--- a/gateapi/http_entity.go
+++ b/gateapi/http_entity.go
@@ -10,6 +10,5 @@
 package swagger
 
 type HttpEntity struct {
-
 	Body *interface{} `json:"body,omitempty"`
 }

--- a/gateapi/image_controller_api.go
+++ b/gateapi/image_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,24 +27,23 @@ var (
 
 type ImageControllerApiService service
 
-
 /* ImageControllerApiService Retrieve a list of images, filtered by cloud provider, region, and account
- The query parameter &#x60;q&#x60; filters the list of images by image name
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "account" (string) account
-     @param "count" (int32) count
-     @param "provider" (string) provider
-     @param "q" (string) q
-     @param "region" (string) region
- @return []interface{}*/
-func (a *ImageControllerApiService) FindImagesUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+The query parameter &#x60;q&#x60; filters the list of images by image name
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "account" (string) account
+    @param "count" (int32) count
+    @param "provider" (string) provider
+    @param "q" (string) q
+    @param "region" (string) region
+@return []interface{}*/
+func (a *ImageControllerApiService) FindImagesUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -85,7 +85,7 @@ func (a *ImageControllerApiService) FindImagesUsingGET(ctx context.Context, loca
 		localVarQueryParams.Add("region", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -96,7 +96,7 @@ func (a *ImageControllerApiService) FindImagesUsingGET(ctx context.Context, loca
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -122,25 +122,24 @@ func (a *ImageControllerApiService) FindImagesUsingGET(ctx context.Context, loca
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ImageControllerApiService Find tags
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param repository repository
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return []interface{}*/
-func (a *ImageControllerApiService) FindTagsUsingGET(ctx context.Context, account string, repository string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param repository repository
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return []interface{}*/
+func (a *ImageControllerApiService) FindTagsUsingGET(ctx context.Context, account string, repository string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -163,7 +162,7 @@ func (a *ImageControllerApiService) FindTagsUsingGET(ctx context.Context, accoun
 	}
 	localVarQueryParams.Add("repository", parameterToString(repository, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -174,7 +173,7 @@ func (a *ImageControllerApiService) FindTagsUsingGET(ctx context.Context, accoun
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -203,26 +202,25 @@ func (a *ImageControllerApiService) FindTagsUsingGET(ctx context.Context, accoun
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ImageControllerApiService Get image details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param imageId imageId
- @param region region
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return []interface{}*/
-func (a *ImageControllerApiService) GetImageDetailsUsingGET(ctx context.Context, account string, imageId string, region string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param imageId imageId
+@param region region
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return []interface{}*/
+func (a *ImageControllerApiService) GetImageDetailsUsingGET(ctx context.Context, account string, imageId string, region string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -246,7 +244,7 @@ func (a *ImageControllerApiService) GetImageDetailsUsingGET(ctx context.Context,
 		localVarQueryParams.Add("provider", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -257,7 +255,7 @@ func (a *ImageControllerApiService) GetImageDetailsUsingGET(ctx context.Context,
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -286,7 +284,5 @@ func (a *ImageControllerApiService) GetImageDetailsUsingGET(ctx context.Context,
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/instance_controller_api.go
+++ b/gateapi/instance_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,23 +27,22 @@ var (
 
 type InstanceControllerApiService service
 
-
 /* InstanceControllerApiService Retrieve an instance&#39;s console output
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param instanceId instanceId
- @param region region
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return interface{}*/
-func (a *InstanceControllerApiService) GetConsoleOutputUsingGET(ctx context.Context, account string, instanceId string, region string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param instanceId instanceId
+@param region region
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return interface{}*/
+func (a *InstanceControllerApiService) GetConsoleOutputUsingGET(ctx context.Context, account string, instanceId string, region string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -66,7 +66,7 @@ func (a *InstanceControllerApiService) GetConsoleOutputUsingGET(ctx context.Cont
 		localVarQueryParams.Add("provider", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -77,7 +77,7 @@ func (a *InstanceControllerApiService) GetConsoleOutputUsingGET(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -106,25 +106,24 @@ func (a *InstanceControllerApiService) GetConsoleOutputUsingGET(ctx context.Cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* InstanceControllerApiService Retrieve an instance&#39;s details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param instanceId instanceId
- @param region region
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return interface{}*/
-func (a *InstanceControllerApiService) GetInstanceDetailsUsingGET(ctx context.Context, account string, instanceId string, region string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param instanceId instanceId
+@param region region
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return interface{}*/
+func (a *InstanceControllerApiService) GetInstanceDetailsUsingGET(ctx context.Context, account string, instanceId string, region string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -142,7 +141,7 @@ func (a *InstanceControllerApiService) GetInstanceDetailsUsingGET(ctx context.Co
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -153,7 +152,7 @@ func (a *InstanceControllerApiService) GetInstanceDetailsUsingGET(ctx context.Co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -182,7 +181,5 @@ func (a *InstanceControllerApiService) GetInstanceDetailsUsingGET(ctx context.Co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/job_controller_api.go
+++ b/gateapi/job_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,24 +27,23 @@ var (
 
 type JobControllerApiService service
 
-
 /* JobControllerApiService Get job
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param applicationName applicationName
- @param name name
- @param region region
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "expand" (string) expand
- @return map[string]interface{}*/
-func (a *JobControllerApiService) GetJobUsingGET(ctx context.Context, account string, applicationName string, name string, region string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param applicationName applicationName
+@param name name
+@param region region
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "expand" (string) expand
+@return map[string]interface{}*/
+func (a *JobControllerApiService) GetJobUsingGET(ctx context.Context, account string, applicationName string, name string, region string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -68,7 +68,7 @@ func (a *JobControllerApiService) GetJobUsingGET(ctx context.Context, account st
 		localVarQueryParams.Add("expand", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -79,7 +79,7 @@ func (a *JobControllerApiService) GetJobUsingGET(ctx context.Context, account st
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -108,7 +108,5 @@ func (a *JobControllerApiService) GetJobUsingGET(ctx context.Context, account st
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/load_balancer_controller_api.go
+++ b/gateapi/load_balancer_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,20 +27,19 @@ var (
 
 type LoadBalancerControllerApiService service
 
-
 /* LoadBalancerControllerApiService Retrieve a list of load balancers for a given cloud provider
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return []interface{}*/
-func (a *LoadBalancerControllerApiService) GetAllUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return []interface{}*/
+func (a *LoadBalancerControllerApiService) GetAllUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -60,7 +60,7 @@ func (a *LoadBalancerControllerApiService) GetAllUsingGET(ctx context.Context, l
 		localVarQueryParams.Add("provider", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -71,7 +71,7 @@ func (a *LoadBalancerControllerApiService) GetAllUsingGET(ctx context.Context, l
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -100,23 +100,22 @@ func (a *LoadBalancerControllerApiService) GetAllUsingGET(ctx context.Context, l
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* LoadBalancerControllerApiService Retrieve a list of load balancers for a given application
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *LoadBalancerControllerApiService) GetApplicationLoadBalancersUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *LoadBalancerControllerApiService) GetApplicationLoadBalancersUsingGET(ctx context.Context, application string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -132,7 +131,7 @@ func (a *LoadBalancerControllerApiService) GetApplicationLoadBalancersUsingGET(c
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -143,7 +142,7 @@ func (a *LoadBalancerControllerApiService) GetApplicationLoadBalancersUsingGET(c
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -172,26 +171,25 @@ func (a *LoadBalancerControllerApiService) GetApplicationLoadBalancersUsingGET(c
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* LoadBalancerControllerApiService Retrieve a load balancer&#39;s details as a single element list for a given account, region, cloud provider and load balancer name
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param name name
- @param region region
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return []interface{}*/
-func (a *LoadBalancerControllerApiService) GetLoadBalancerDetailsUsingGET(ctx context.Context, account string, name string, region string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param name name
+@param region region
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return []interface{}*/
+func (a *LoadBalancerControllerApiService) GetLoadBalancerDetailsUsingGET(ctx context.Context, account string, name string, region string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -215,7 +213,7 @@ func (a *LoadBalancerControllerApiService) GetLoadBalancerDetailsUsingGET(ctx co
 		localVarQueryParams.Add("provider", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -226,7 +224,7 @@ func (a *LoadBalancerControllerApiService) GetLoadBalancerDetailsUsingGET(ctx co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -255,24 +253,23 @@ func (a *LoadBalancerControllerApiService) GetLoadBalancerDetailsUsingGET(ctx co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* LoadBalancerControllerApiService Retrieve a load balancer for a given cloud provider
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param name name
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return map[string]interface{}*/
-func (a *LoadBalancerControllerApiService) GetLoadBalancerUsingGET(ctx context.Context, name string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param name name
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return map[string]interface{}*/
+func (a *LoadBalancerControllerApiService) GetLoadBalancerUsingGET(ctx context.Context, name string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -294,7 +291,7 @@ func (a *LoadBalancerControllerApiService) GetLoadBalancerUsingGET(ctx context.C
 		localVarQueryParams.Add("provider", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -305,7 +302,7 @@ func (a *LoadBalancerControllerApiService) GetLoadBalancerUsingGET(ctx context.C
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -334,7 +331,5 @@ func (a *LoadBalancerControllerApiService) GetLoadBalancerUsingGET(ctx context.C
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/network_controller_api.go
+++ b/gateapi/network_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,20 +27,19 @@ var (
 
 type NetworkControllerApiService service
 
-
 /* NetworkControllerApiService Retrieve a list of networks for a given cloud provider
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param cloudProvider cloudProvider
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *NetworkControllerApiService) AllByCloudProviderUsingGET(ctx context.Context, cloudProvider string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param cloudProvider cloudProvider
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *NetworkControllerApiService) AllByCloudProviderUsingGET(ctx context.Context, cloudProvider string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -55,7 +55,7 @@ func (a *NetworkControllerApiService) AllByCloudProviderUsingGET(ctx context.Con
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -66,7 +66,7 @@ func (a *NetworkControllerApiService) AllByCloudProviderUsingGET(ctx context.Con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -95,22 +95,21 @@ func (a *NetworkControllerApiService) AllByCloudProviderUsingGET(ctx context.Con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* NetworkControllerApiService Retrieve a list of networks, grouped by cloud provider
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return map[string]interface{}*/
-func (a *NetworkControllerApiService) AllUsingGET2(ctx context.Context, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return map[string]interface{}*/
+func (a *NetworkControllerApiService) AllUsingGET2(ctx context.Context, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -125,7 +124,7 @@ func (a *NetworkControllerApiService) AllUsingGET2(ctx context.Context, localVar
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -136,7 +135,7 @@ func (a *NetworkControllerApiService) AllUsingGET2(ctx context.Context, localVar
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -165,7 +164,5 @@ func (a *NetworkControllerApiService) AllUsingGET2(ctx context.Context, localVar
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/pipeline_config_controller_api.go
+++ b/gateapi/pipeline_config_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,18 +27,17 @@ var (
 
 type PipelineConfigControllerApiService service
 
-
 /* PipelineConfigControllerApiService Convert a pipeline config to a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param pipelineConfigId pipelineConfigId
- @return string*/
-func (a *PipelineConfigControllerApiService) ConvertPipelineConfigToPipelineTemplateUsingGET(ctx context.Context, pipelineConfigId string) (string,  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param pipelineConfigId pipelineConfigId
+@return string*/
+func (a *PipelineConfigControllerApiService) ConvertPipelineConfigToPipelineTemplateUsingGET(ctx context.Context, pipelineConfigId string) (string, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  string
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     string
 	)
 
 	// create path and map variables
@@ -48,9 +48,8 @@ func (a *PipelineConfigControllerApiService) ConvertPipelineConfigToPipelineTemp
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -61,7 +60,7 @@ func (a *PipelineConfigControllerApiService) ConvertPipelineConfigToPipelineTemp
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -87,20 +86,19 @@ func (a *PipelineConfigControllerApiService) ConvertPipelineConfigToPipelineTemp
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineConfigControllerApiService Get all pipeline configs.
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *PipelineConfigControllerApiService) GetAllPipelineConfigsUsingGET(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *PipelineConfigControllerApiService) GetAllPipelineConfigsUsingGET(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -110,9 +108,8 @@ func (a *PipelineConfigControllerApiService) GetAllPipelineConfigsUsingGET(ctx c
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -123,7 +120,7 @@ func (a *PipelineConfigControllerApiService) GetAllPipelineConfigsUsingGET(ctx c
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -149,23 +146,22 @@ func (a *PipelineConfigControllerApiService) GetAllPipelineConfigsUsingGET(ctx c
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineConfigControllerApiService Get pipeline config history.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param pipelineConfigId pipelineConfigId
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "limit" (int32) limit
- @return []interface{}*/
-func (a *PipelineConfigControllerApiService) GetPipelineConfigHistoryUsingGET(ctx context.Context, pipelineConfigId string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param pipelineConfigId pipelineConfigId
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "limit" (int32) limit
+@return []interface{}*/
+func (a *PipelineConfigControllerApiService) GetPipelineConfigHistoryUsingGET(ctx context.Context, pipelineConfigId string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -184,7 +180,7 @@ func (a *PipelineConfigControllerApiService) GetPipelineConfigHistoryUsingGET(ct
 		localVarQueryParams.Add("limit", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -195,7 +191,7 @@ func (a *PipelineConfigControllerApiService) GetPipelineConfigHistoryUsingGET(ct
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -221,7 +217,5 @@ func (a *PipelineConfigControllerApiService) GetPipelineConfigHistoryUsingGET(ct
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/pipeline_controller_api.go
+++ b/gateapi/pipeline_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,20 +27,19 @@ var (
 
 type PipelineControllerApiService service
 
-
 /* PipelineControllerApiService Cancel a pipeline execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "force" (bool) force
-     @param "reason" (string) reason
- @return */
-func (a *PipelineControllerApiService) CancelPipelineUsingPUT1(ctx context.Context, id string, localVarOptionals map[string]interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "force" (bool) force
+    @param "reason" (string) reason
+@return */
+func (a *PipelineControllerApiService) CancelPipelineUsingPUT1(ctx context.Context, id string, localVarOptionals map[string]interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -64,7 +64,7 @@ func (a *PipelineControllerApiService) CancelPipelineUsingPUT1(ctx context.Conte
 		localVarQueryParams.Add("reason", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -75,7 +75,7 @@ func (a *PipelineControllerApiService) CancelPipelineUsingPUT1(ctx context.Conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -101,16 +101,16 @@ func (a *PipelineControllerApiService) CancelPipelineUsingPUT1(ctx context.Conte
 }
 
 /* PipelineControllerApiService Delete a pipeline definition
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param pipelineName pipelineName
- @return */
-func (a *PipelineControllerApiService) DeletePipelineUsingDELETE(ctx context.Context, application string, pipelineName string) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param pipelineName pipelineName
+@return */
+func (a *PipelineControllerApiService) DeletePipelineUsingDELETE(ctx context.Context, application string, pipelineName string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -122,9 +122,8 @@ func (a *PipelineControllerApiService) DeletePipelineUsingDELETE(ctx context.Con
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -135,7 +134,7 @@ func (a *PipelineControllerApiService) DeletePipelineUsingDELETE(ctx context.Con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -161,16 +160,16 @@ func (a *PipelineControllerApiService) DeletePipelineUsingDELETE(ctx context.Con
 }
 
 /* PipelineControllerApiService Delete a pipeline execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) DeletePipelineUsingDELETE1(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) DeletePipelineUsingDELETE1(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -181,9 +180,8 @@ func (a *PipelineControllerApiService) DeletePipelineUsingDELETE1(ctx context.Co
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -194,7 +192,7 @@ func (a *PipelineControllerApiService) DeletePipelineUsingDELETE1(ctx context.Co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -220,23 +218,22 @@ func (a *PipelineControllerApiService) DeletePipelineUsingDELETE1(ctx context.Co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Evaluate a pipeline expression at a specific stage using the provided execution as context
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param expression expression
- @param id id
- @param stageId stageId
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) EvaluateExpressionForExecutionAtStageUsingGET(ctx context.Context, expression string, id string, stageId string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param expression expression
+@param id id
+@param stageId stageId
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) EvaluateExpressionForExecutionAtStageUsingGET(ctx context.Context, expression string, id string, stageId string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -248,10 +245,9 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionAtStageUsin
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	localVarQueryParams.Add("expression", parameterToString(expression, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -262,7 +258,7 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionAtStageUsin
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -288,22 +284,21 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionAtStageUsin
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Evaluate a pipeline expression using the provided execution as context
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param expression expression
- @param id id
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) EvaluateExpressionForExecutionUsingGET(ctx context.Context, expression string, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param expression expression
+@param id id
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) EvaluateExpressionForExecutionUsingGET(ctx context.Context, expression string, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -314,10 +309,9 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionUsingGET(ct
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	localVarQueryParams.Add("expression", parameterToString(expression, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -328,7 +322,7 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionUsingGET(ct
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -354,22 +348,21 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionUsingGET(ct
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Evaluate a pipeline expression using the provided execution as context
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param pipelineExpression pipelineExpression
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) EvaluateExpressionForExecutionViaPOSTUsingPOST(ctx context.Context, id string, pipelineExpression interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param pipelineExpression pipelineExpression
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) EvaluateExpressionForExecutionViaPOSTUsingPOST(ctx context.Context, id string, pipelineExpression interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -380,9 +373,8 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionViaPOSTUsin
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -393,7 +385,7 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionViaPOSTUsin
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -421,25 +413,24 @@ func (a *PipelineControllerApiService) EvaluateExpressionForExecutionViaPOSTUsin
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Evaluate variables same as Evaluate Variables stage using the provided execution as context
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param executionId Execution id to run against
- @param expressions List of variables/expressions to evaluate
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "requisiteStageRefIds" (string) Comma separated list of requisite stage IDs for the evaluation stage
-     @param "spelVersion" (string) Version of SpEL evaluation logic to use (v3 or v4)
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) EvaluateVariablesUsingPOST(ctx context.Context, executionId string, expressions []Mapstringstring, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param executionId Execution id to run against
+@param expressions List of variables/expressions to evaluate
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "requisiteStageRefIds" (string) Comma separated list of requisite stage IDs for the evaluation stage
+    @param "spelVersion" (string) Version of SpEL evaluation logic to use (v3 or v4)
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) EvaluateVariablesUsingPOST(ctx context.Context, executionId string, expressions []Mapstringstring, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -464,7 +455,7 @@ func (a *PipelineControllerApiService) EvaluateVariablesUsingPOST(ctx context.Co
 		localVarQueryParams.Add("spelVersion", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -475,7 +466,7 @@ func (a *PipelineControllerApiService) EvaluateVariablesUsingPOST(ctx context.Co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -503,21 +494,20 @@ func (a *PipelineControllerApiService) EvaluateVariablesUsingPOST(ctx context.Co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Retrieve a pipeline execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return interface{}*/
-func (a *PipelineControllerApiService) GetPipelineUsingGET(ctx context.Context, id string) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return interface{}*/
+func (a *PipelineControllerApiService) GetPipelineUsingGET(ctx context.Context, id string) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -528,9 +518,8 @@ func (a *PipelineControllerApiService) GetPipelineUsingGET(ctx context.Context, 
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -541,7 +530,7 @@ func (a *PipelineControllerApiService) GetPipelineUsingGET(ctx context.Context, 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -567,23 +556,22 @@ func (a *PipelineControllerApiService) GetPipelineUsingGET(ctx context.Context, 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Trigger a pipeline execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param pipelineNameOrId pipelineNameOrId
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "trigger" (interface{}) trigger
- @return */
-func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx context.Context, application string, pipelineNameOrId string, localVarOptionals map[string]interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param pipelineNameOrId pipelineNameOrId
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "trigger" (interface{}) trigger
+@return */
+func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx context.Context, application string, pipelineNameOrId string, localVarOptionals map[string]interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -595,9 +583,8 @@ func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx contex
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -608,7 +595,7 @@ func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -638,19 +625,19 @@ func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx contex
 }
 
 /* PipelineControllerApiService Trigger a pipeline execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param pipelineNameOrId pipelineNameOrId
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "trigger" (interface{}) trigger
- @return HttpEntity*/
-func (a *PipelineControllerApiService) InvokePipelineConfigViaEchoUsingPOST(ctx context.Context, application string, pipelineNameOrId string, localVarOptionals map[string]interface{}) (HttpEntity,  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param pipelineNameOrId pipelineNameOrId
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "trigger" (interface{}) trigger
+@return HttpEntity*/
+func (a *PipelineControllerApiService) InvokePipelineConfigViaEchoUsingPOST(ctx context.Context, application string, pipelineNameOrId string, localVarOptionals map[string]interface{}) (HttpEntity, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  HttpEntity
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     HttpEntity
 	)
 
 	// create path and map variables
@@ -662,9 +649,8 @@ func (a *PipelineControllerApiService) InvokePipelineConfigViaEchoUsingPOST(ctx 
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -675,7 +661,7 @@ func (a *PipelineControllerApiService) InvokePipelineConfigViaEchoUsingPOST(ctx 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -705,20 +691,19 @@ func (a *PipelineControllerApiService) InvokePipelineConfigViaEchoUsingPOST(ctx 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Pause a pipeline execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return */
-func (a *PipelineControllerApiService) PausePipelineUsingPUT(ctx context.Context, id string) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return */
+func (a *PipelineControllerApiService) PausePipelineUsingPUT(ctx context.Context, id string) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -729,9 +714,8 @@ func (a *PipelineControllerApiService) PausePipelineUsingPUT(ctx context.Context
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -742,7 +726,7 @@ func (a *PipelineControllerApiService) PausePipelineUsingPUT(ctx context.Context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -768,15 +752,15 @@ func (a *PipelineControllerApiService) PausePipelineUsingPUT(ctx context.Context
 }
 
 /* PipelineControllerApiService Rename a pipeline definition
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param renameCommand renameCommand
- @return */
-func (a *PipelineControllerApiService) RenamePipelineUsingPOST(ctx context.Context, renameCommand interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param renameCommand renameCommand
+@return */
+func (a *PipelineControllerApiService) RenamePipelineUsingPOST(ctx context.Context, renameCommand interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -786,9 +770,8 @@ func (a *PipelineControllerApiService) RenamePipelineUsingPOST(ctx context.Conte
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -799,7 +782,7 @@ func (a *PipelineControllerApiService) RenamePipelineUsingPOST(ctx context.Conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -827,18 +810,18 @@ func (a *PipelineControllerApiService) RenamePipelineUsingPOST(ctx context.Conte
 }
 
 /* PipelineControllerApiService Restart a stage execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param context context
- @param id id
- @param stageId stageId
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) RestartStageUsingPUT(ctx context.Context, context interface{}, id string, stageId string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param context context
+@param id id
+@param stageId stageId
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) RestartStageUsingPUT(ctx context.Context, context interface{}, id string, stageId string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -850,9 +833,8 @@ func (a *PipelineControllerApiService) RestartStageUsingPUT(ctx context.Context,
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -863,7 +845,7 @@ func (a *PipelineControllerApiService) RestartStageUsingPUT(ctx context.Context,
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -891,21 +873,20 @@ func (a *PipelineControllerApiService) RestartStageUsingPUT(ctx context.Context,
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Resume a pipeline execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) ResumePipelineUsingPUT(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) ResumePipelineUsingPUT(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -916,9 +897,8 @@ func (a *PipelineControllerApiService) ResumePipelineUsingPUT(ctx context.Contex
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -929,7 +909,7 @@ func (a *PipelineControllerApiService) ResumePipelineUsingPUT(ctx context.Contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -955,20 +935,19 @@ func (a *PipelineControllerApiService) ResumePipelineUsingPUT(ctx context.Contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Save a pipeline definition
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param pipeline pipeline
- @return */
-func (a *PipelineControllerApiService) SavePipelineUsingPOST(ctx context.Context, pipeline interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param pipeline pipeline
+@return */
+func (a *PipelineControllerApiService) SavePipelineUsingPOST(ctx context.Context, pipeline interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -978,9 +957,8 @@ func (a *PipelineControllerApiService) SavePipelineUsingPOST(ctx context.Context
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -991,7 +969,7 @@ func (a *PipelineControllerApiService) SavePipelineUsingPOST(ctx context.Context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -1019,16 +997,16 @@ func (a *PipelineControllerApiService) SavePipelineUsingPOST(ctx context.Context
 }
 
 /* PipelineControllerApiService Initiate a pipeline execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param map_ map
- @return ResponseEntity*/
-func (a *PipelineControllerApiService) StartUsingPOST(ctx context.Context, map_ interface{}) (ResponseEntity,  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param map_ map
+@return ResponseEntity*/
+func (a *PipelineControllerApiService) StartUsingPOST(ctx context.Context, map_ interface{}) (ResponseEntity, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  ResponseEntity
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     ResponseEntity
 	)
 
 	// create path and map variables
@@ -1038,9 +1016,8 @@ func (a *PipelineControllerApiService) StartUsingPOST(ctx context.Context, map_ 
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -1051,7 +1028,7 @@ func (a *PipelineControllerApiService) StartUsingPOST(ctx context.Context, map_ 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -1079,22 +1056,21 @@ func (a *PipelineControllerApiService) StartUsingPOST(ctx context.Context, map_ 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Update a pipeline definition
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param pipeline pipeline
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) UpdatePipelineUsingPUT(ctx context.Context, id string, pipeline interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param pipeline pipeline
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) UpdatePipelineUsingPUT(ctx context.Context, id string, pipeline interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -1105,9 +1081,8 @@ func (a *PipelineControllerApiService) UpdatePipelineUsingPUT(ctx context.Contex
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -1118,7 +1093,7 @@ func (a *PipelineControllerApiService) UpdatePipelineUsingPUT(ctx context.Contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -1146,23 +1121,22 @@ func (a *PipelineControllerApiService) UpdatePipelineUsingPUT(ctx context.Contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Update a stage execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param context context
- @param id id
- @param stageId stageId
- @return map[string]interface{}*/
-func (a *PipelineControllerApiService) UpdateStageUsingPATCH(ctx context.Context, context interface{}, id string, stageId string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param context context
+@param id id
+@param stageId stageId
+@return map[string]interface{}*/
+func (a *PipelineControllerApiService) UpdateStageUsingPATCH(ctx context.Context, context interface{}, id string, stageId string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Patch")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -1174,9 +1148,8 @@ func (a *PipelineControllerApiService) UpdateStageUsingPATCH(ctx context.Context
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -1187,7 +1160,7 @@ func (a *PipelineControllerApiService) UpdateStageUsingPATCH(ctx context.Context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -1215,7 +1188,5 @@ func (a *PipelineControllerApiService) UpdateStageUsingPATCH(ctx context.Context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/pipeline_template_dependent.go
+++ b/gateapi/pipeline_template_dependent.go
@@ -10,7 +10,6 @@
 package swagger
 
 type PipelineTemplateDependent struct {
-
 	PipelineConfigId string `json:"pipelineConfigId,omitempty"`
 
 	Application string `json:"application,omitempty"`

--- a/gateapi/pipeline_templates_controller_api.go
+++ b/gateapi/pipeline_templates_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,17 +27,16 @@ var (
 
 type PipelineTemplatesControllerApiService service
 
-
 /* PipelineTemplatesControllerApiService Create a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param pipelineTemplate pipelineTemplate
- @return */
-func (a *PipelineTemplatesControllerApiService) CreateUsingPOST(ctx context.Context, pipelineTemplate interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param pipelineTemplate pipelineTemplate
+@return */
+func (a *PipelineTemplatesControllerApiService) CreateUsingPOST(ctx context.Context, pipelineTemplate interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -46,9 +46,8 @@ func (a *PipelineTemplatesControllerApiService) CreateUsingPOST(ctx context.Cont
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -59,7 +58,7 @@ func (a *PipelineTemplatesControllerApiService) CreateUsingPOST(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -87,18 +86,18 @@ func (a *PipelineTemplatesControllerApiService) CreateUsingPOST(ctx context.Cont
 }
 
 /* PipelineTemplatesControllerApiService Delete a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "application" (string) application
- @return map[string]interface{}*/
-func (a *PipelineTemplatesControllerApiService) DeleteUsingDELETE(ctx context.Context, id string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "application" (string) application
+@return map[string]interface{}*/
+func (a *PipelineTemplatesControllerApiService) DeleteUsingDELETE(ctx context.Context, id string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -117,7 +116,7 @@ func (a *PipelineTemplatesControllerApiService) DeleteUsingDELETE(ctx context.Co
 		localVarQueryParams.Add("application", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -128,7 +127,7 @@ func (a *PipelineTemplatesControllerApiService) DeleteUsingDELETE(ctx context.Co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -154,21 +153,20 @@ func (a *PipelineTemplatesControllerApiService) DeleteUsingDELETE(ctx context.Co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineTemplatesControllerApiService Get a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *PipelineTemplatesControllerApiService) GetUsingGET(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *PipelineTemplatesControllerApiService) GetUsingGET(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -179,9 +177,8 @@ func (a *PipelineTemplatesControllerApiService) GetUsingGET(ctx context.Context,
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -192,7 +189,7 @@ func (a *PipelineTemplatesControllerApiService) GetUsingGET(ctx context.Context,
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -218,23 +215,22 @@ func (a *PipelineTemplatesControllerApiService) GetUsingGET(ctx context.Context,
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineTemplatesControllerApiService List all pipelines that implement a pipeline template
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "recursive" (bool) recursive
- @return []interface{}*/
-func (a *PipelineTemplatesControllerApiService) ListPipelineTemplateDependentsUsingGET(ctx context.Context, id string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "recursive" (bool) recursive
+@return []interface{}*/
+func (a *PipelineTemplatesControllerApiService) ListPipelineTemplateDependentsUsingGET(ctx context.Context, id string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -253,7 +249,7 @@ func (a *PipelineTemplatesControllerApiService) ListPipelineTemplateDependentsUs
 		localVarQueryParams.Add("recursive", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -264,7 +260,7 @@ func (a *PipelineTemplatesControllerApiService) ListPipelineTemplateDependentsUs
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -290,22 +286,21 @@ func (a *PipelineTemplatesControllerApiService) ListPipelineTemplateDependentsUs
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineTemplatesControllerApiService List pipeline templates.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "scopes" ([]string) scopes
- @return []interface{}*/
-func (a *PipelineTemplatesControllerApiService) ListUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "scopes" ([]string) scopes
+@return []interface{}*/
+func (a *PipelineTemplatesControllerApiService) ListUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -315,12 +310,11 @@ func (a *PipelineTemplatesControllerApiService) ListUsingGET(ctx context.Context
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	if localVarTempParam, localVarOk := localVarOptionals["scopes"].([]string); localVarOk {
 		localVarQueryParams.Add("scopes", parameterToString(localVarTempParam, "multi"))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -331,7 +325,7 @@ func (a *PipelineTemplatesControllerApiService) ListUsingGET(ctx context.Context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -357,24 +351,23 @@ func (a *PipelineTemplatesControllerApiService) ListUsingGET(ctx context.Context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineTemplatesControllerApiService Resolve a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param source source
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "executionId" (string) executionId
-     @param "pipelineConfigId" (string) pipelineConfigId
- @return map[string]interface{}*/
-func (a *PipelineTemplatesControllerApiService) ResolveTemplatesUsingGET(ctx context.Context, source string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param source source
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "executionId" (string) executionId
+    @param "pipelineConfigId" (string) pipelineConfigId
+@return map[string]interface{}*/
+func (a *PipelineTemplatesControllerApiService) ResolveTemplatesUsingGET(ctx context.Context, source string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -399,7 +392,7 @@ func (a *PipelineTemplatesControllerApiService) ResolveTemplatesUsingGET(ctx con
 	}
 	localVarQueryParams.Add("source", parameterToString(source, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -410,7 +403,7 @@ func (a *PipelineTemplatesControllerApiService) ResolveTemplatesUsingGET(ctx con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -436,23 +429,22 @@ func (a *PipelineTemplatesControllerApiService) ResolveTemplatesUsingGET(ctx con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineTemplatesControllerApiService Update a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param pipelineTemplate pipelineTemplate
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "skipPlanDependents" (bool) skipPlanDependents
- @return */
-func (a *PipelineTemplatesControllerApiService) UpdateUsingPOST(ctx context.Context, id string, pipelineTemplate interface{}, localVarOptionals map[string]interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param pipelineTemplate pipelineTemplate
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "skipPlanDependents" (bool) skipPlanDependents
+@return */
+func (a *PipelineTemplatesControllerApiService) UpdateUsingPOST(ctx context.Context, id string, pipelineTemplate interface{}, localVarOptionals map[string]interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -471,7 +463,7 @@ func (a *PipelineTemplatesControllerApiService) UpdateUsingPOST(ctx context.Cont
 		localVarQueryParams.Add("skipPlanDependents", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -482,7 +474,7 @@ func (a *PipelineTemplatesControllerApiService) UpdateUsingPOST(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -508,4 +500,3 @@ func (a *PipelineTemplatesControllerApiService) UpdateUsingPOST(ctx context.Cont
 
 	return localVarHttpResponse, err
 }
-

--- a/gateapi/project_controller_api.go
+++ b/gateapi/project_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,21 +27,20 @@ var (
 
 type ProjectControllerApiService service
 
-
 /* ProjectControllerApiService Get all pipelines for project
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "limit" (int32) limit
-     @param "statuses" (string) statuses
- @return []interface{}*/
-func (a *ProjectControllerApiService) AllPipelinesForProjectUsingGET(ctx context.Context, id string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "limit" (int32) limit
+    @param "statuses" (string) statuses
+@return []interface{}*/
+func (a *ProjectControllerApiService) AllPipelinesForProjectUsingGET(ctx context.Context, id string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -65,7 +65,7 @@ func (a *ProjectControllerApiService) AllPipelinesForProjectUsingGET(ctx context
 		localVarQueryParams.Add("statuses", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -76,7 +76,7 @@ func (a *ProjectControllerApiService) AllPipelinesForProjectUsingGET(ctx context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -102,20 +102,19 @@ func (a *ProjectControllerApiService) AllPipelinesForProjectUsingGET(ctx context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ProjectControllerApiService Get all projects
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *ProjectControllerApiService) AllUsingGET3(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *ProjectControllerApiService) AllUsingGET3(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -125,9 +124,8 @@ func (a *ProjectControllerApiService) AllUsingGET3(ctx context.Context) ([]inter
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -138,7 +136,7 @@ func (a *ProjectControllerApiService) AllUsingGET3(ctx context.Context) ([]inter
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -164,23 +162,22 @@ func (a *ProjectControllerApiService) AllUsingGET3(ctx context.Context) ([]inter
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ProjectControllerApiService Get a project&#39;s clusters
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *ProjectControllerApiService) GetClustersUsingGET3(ctx context.Context, id string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *ProjectControllerApiService) GetClustersUsingGET3(ctx context.Context, id string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -196,7 +193,7 @@ func (a *ProjectControllerApiService) GetClustersUsingGET3(ctx context.Context, 
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -207,7 +204,7 @@ func (a *ProjectControllerApiService) GetClustersUsingGET3(ctx context.Context, 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -236,21 +233,20 @@ func (a *ProjectControllerApiService) GetClustersUsingGET3(ctx context.Context, 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ProjectControllerApiService Get a project
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *ProjectControllerApiService) GetUsingGET1(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *ProjectControllerApiService) GetUsingGET1(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -261,9 +257,8 @@ func (a *ProjectControllerApiService) GetUsingGET1(ctx context.Context, id strin
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -274,7 +269,7 @@ func (a *ProjectControllerApiService) GetUsingGET1(ctx context.Context, id strin
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -300,7 +295,5 @@ func (a *ProjectControllerApiService) GetUsingGET1(ctx context.Context, id strin
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/pubsub_subscription_controller_api.go
+++ b/gateapi/pubsub_subscription_controller_api.go
@@ -10,12 +10,13 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -25,17 +26,16 @@ var (
 
 type PubsubSubscriptionControllerApiService service
 
-
 /* PubsubSubscriptionControllerApiService Retrieve the list of pub/sub subscriptions configured in Echo.
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []Mapstringstring*/
-func (a *PubsubSubscriptionControllerApiService) AllUsingGET4(ctx context.Context) ([]Mapstringstring,  *http.Response, error) {
+func (a *PubsubSubscriptionControllerApiService) AllUsingGET4(ctx context.Context) ([]Mapstringstring, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []Mapstringstring
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []Mapstringstring
 	)
 
 	// create path and map variables
@@ -45,9 +45,8 @@ func (a *PubsubSubscriptionControllerApiService) AllUsingGET4(ctx context.Contex
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -58,7 +57,7 @@ func (a *PubsubSubscriptionControllerApiService) AllUsingGET4(ctx context.Contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -84,7 +83,5 @@ func (a *PubsubSubscriptionControllerApiService) AllUsingGET4(ctx context.Contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/reorder_pipelines_command.go
+++ b/gateapi/reorder_pipelines_command.go
@@ -10,7 +10,6 @@
 package swagger
 
 type ReorderPipelinesCommand struct {
-
 	IdsToIndices map[string]int32 `json:"idsToIndices,omitempty"`
 
 	Application string `json:"application,omitempty"`

--- a/gateapi/reorder_pipelines_controller_api.go
+++ b/gateapi/reorder_pipelines_controller_api.go
@@ -10,12 +10,13 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -25,18 +26,17 @@ var (
 
 type ReorderPipelinesControllerApiService service
 
-
 /* ReorderPipelinesControllerApiService Re-order pipelines
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param reorderPipelinesCommand reorderPipelinesCommand
- @return interface{}*/
-func (a *ReorderPipelinesControllerApiService) ReorderPipelinesUsingPOST(ctx context.Context, reorderPipelinesCommand ReorderPipelinesCommand) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param reorderPipelinesCommand reorderPipelinesCommand
+@return interface{}*/
+func (a *ReorderPipelinesControllerApiService) ReorderPipelinesUsingPOST(ctx context.Context, reorderPipelinesCommand ReorderPipelinesCommand) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -46,9 +46,8 @@ func (a *ReorderPipelinesControllerApiService) ReorderPipelinesUsingPOST(ctx con
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -59,7 +58,7 @@ func (a *ReorderPipelinesControllerApiService) ReorderPipelinesUsingPOST(ctx con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -87,7 +86,5 @@ func (a *ReorderPipelinesControllerApiService) ReorderPipelinesUsingPOST(ctx con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/response_entity.go
+++ b/gateapi/response_entity.go
@@ -10,7 +10,6 @@
 package swagger
 
 type ResponseEntity struct {
-
 	StatusCode string `json:"statusCode,omitempty"`
 
 	Body *interface{} `json:"body,omitempty"`

--- a/gateapi/search_controller_api.go
+++ b/gateapi/search_controller_api.go
@@ -10,12 +10,13 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -25,25 +26,24 @@ var (
 
 type SearchControllerApiService service
 
-
 /* SearchControllerApiService Search infrastructure
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param type_ type
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "allowShortQuery" (bool) allowShortQuery
-     @param "page" (int32) page
-     @param "pageSize" (int32) pageSize
-     @param "platform" (string) platform
-     @param "q" (string) q
- @return []interface{}*/
-func (a *SearchControllerApiService) SearchUsingGET(ctx context.Context, type_ string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param type_ type
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "allowShortQuery" (bool) allowShortQuery
+    @param "page" (int32) page
+    @param "pageSize" (int32) pageSize
+    @param "platform" (string) platform
+    @param "q" (string) q
+@return []interface{}*/
+func (a *SearchControllerApiService) SearchUsingGET(ctx context.Context, type_ string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -89,7 +89,7 @@ func (a *SearchControllerApiService) SearchUsingGET(ctx context.Context, type_ s
 	}
 	localVarQueryParams.Add("type", parameterToString(type_, ""))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -100,7 +100,7 @@ func (a *SearchControllerApiService) SearchUsingGET(ctx context.Context, type_ s
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -129,7 +129,5 @@ func (a *SearchControllerApiService) SearchUsingGET(ctx context.Context, type_ s
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/security_group_controller_api.go
+++ b/gateapi/security_group_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,21 +27,20 @@ var (
 
 type SecurityGroupControllerApiService service
 
-
 /* SecurityGroupControllerApiService Retrieve a list of security groups for a given account, grouped by region
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
- @return interface{}*/
-func (a *SecurityGroupControllerApiService) AllByAccountUsingGET1(ctx context.Context, account string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+@return interface{}*/
+func (a *SecurityGroupControllerApiService) AllByAccountUsingGET1(ctx context.Context, account string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -62,7 +62,7 @@ func (a *SecurityGroupControllerApiService) AllByAccountUsingGET1(ctx context.Co
 		localVarQueryParams.Add("provider", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -73,7 +73,7 @@ func (a *SecurityGroupControllerApiService) AllByAccountUsingGET1(ctx context.Co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -102,23 +102,22 @@ func (a *SecurityGroupControllerApiService) AllByAccountUsingGET1(ctx context.Co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* SecurityGroupControllerApiService Retrieve a list of security groups, grouped by account, cloud provider, and region
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "id" (string) id
- @return interface{}*/
-func (a *SecurityGroupControllerApiService) AllUsingGET5(ctx context.Context, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "id" (string) id
+@return interface{}*/
+func (a *SecurityGroupControllerApiService) AllUsingGET5(ctx context.Context, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -139,7 +138,7 @@ func (a *SecurityGroupControllerApiService) AllUsingGET5(ctx context.Context, lo
 		localVarQueryParams.Add("id", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -150,7 +149,7 @@ func (a *SecurityGroupControllerApiService) AllUsingGET5(ctx context.Context, lo
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -179,27 +178,26 @@ func (a *SecurityGroupControllerApiService) AllUsingGET5(ctx context.Context, lo
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* SecurityGroupControllerApiService Retrieve a security group&#39;s details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param name name
- @param region region
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "provider" (string) provider
-     @param "vpcId" (string) vpcId
- @return interface{}*/
-func (a *SecurityGroupControllerApiService) GetSecurityGroupUsingGET1(ctx context.Context, account string, name string, region string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param name name
+@param region region
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "provider" (string) provider
+    @param "vpcId" (string) vpcId
+@return interface{}*/
+func (a *SecurityGroupControllerApiService) GetSecurityGroupUsingGET1(ctx context.Context, account string, name string, region string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -229,7 +227,7 @@ func (a *SecurityGroupControllerApiService) GetSecurityGroupUsingGET1(ctx contex
 		localVarQueryParams.Add("vpcId", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -240,7 +238,7 @@ func (a *SecurityGroupControllerApiService) GetSecurityGroupUsingGET1(ctx contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -269,7 +267,5 @@ func (a *SecurityGroupControllerApiService) GetSecurityGroupUsingGET1(ctx contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/server_group_controller_api.go
+++ b/gateapi/server_group_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,24 +27,23 @@ var (
 
 type ServerGroupControllerApiService service
 
-
 /* ServerGroupControllerApiService Retrieve a server group&#39;s details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param applicationName applicationName
- @param region region
- @param serverGroupName serverGroupName
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "includeDetails" (string) includeDetails
- @return interface{}*/
-func (a *ServerGroupControllerApiService) GetServerGroupDetailsUsingGET(ctx context.Context, account string, applicationName string, region string, serverGroupName string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param applicationName applicationName
+@param region region
+@param serverGroupName serverGroupName
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "includeDetails" (string) includeDetails
+@return interface{}*/
+func (a *ServerGroupControllerApiService) GetServerGroupDetailsUsingGET(ctx context.Context, account string, applicationName string, region string, serverGroupName string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -68,7 +68,7 @@ func (a *ServerGroupControllerApiService) GetServerGroupDetailsUsingGET(ctx cont
 		localVarQueryParams.Add("includeDetails", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -79,7 +79,7 @@ func (a *ServerGroupControllerApiService) GetServerGroupDetailsUsingGET(ctx cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -108,26 +108,25 @@ func (a *ServerGroupControllerApiService) GetServerGroupDetailsUsingGET(ctx cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* ServerGroupControllerApiService Retrieve a list of server groups for a given application
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param applicationName applicationName
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
-     @param "cloudProvider" (string) cloudProvider
-     @param "clusters" (string) clusters
-     @param "expand" (string) expand
- @return []interface{}*/
-func (a *ServerGroupControllerApiService) GetServerGroupsForApplicationUsingGET(ctx context.Context, applicationName string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param applicationName applicationName
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+    @param "cloudProvider" (string) cloudProvider
+    @param "clusters" (string) clusters
+    @param "expand" (string) expand
+@return []interface{}*/
+func (a *ServerGroupControllerApiService) GetServerGroupsForApplicationUsingGET(ctx context.Context, applicationName string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -161,7 +160,7 @@ func (a *ServerGroupControllerApiService) GetServerGroupsForApplicationUsingGET(
 		localVarQueryParams.Add("expand", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -172,7 +171,7 @@ func (a *ServerGroupControllerApiService) GetServerGroupsForApplicationUsingGET(
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -201,7 +200,5 @@ func (a *ServerGroupControllerApiService) GetServerGroupsForApplicationUsingGET(
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/server_group_manager_controller_api.go
+++ b/gateapi/server_group_manager_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,18 +27,17 @@ var (
 
 type ServerGroupManagerControllerApiService service
 
-
 /* ServerGroupManagerControllerApiService Retrieve a list of server group managers for an application
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @return []interface{}*/
-func (a *ServerGroupManagerControllerApiService) GetServerGroupManagersForApplicationUsingGET(ctx context.Context, application string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@return []interface{}*/
+func (a *ServerGroupManagerControllerApiService) GetServerGroupManagersForApplicationUsingGET(ctx context.Context, application string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -48,9 +48,8 @@ func (a *ServerGroupManagerControllerApiService) GetServerGroupManagersForApplic
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -61,7 +60,7 @@ func (a *ServerGroupManagerControllerApiService) GetServerGroupManagersForApplic
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -87,7 +86,5 @@ func (a *ServerGroupManagerControllerApiService) GetServerGroupManagersForApplic
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/snapshot_controller_api.go
+++ b/gateapi/snapshot_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,19 +27,18 @@ var (
 
 type SnapshotControllerApiService service
 
-
 /* SnapshotControllerApiService Get current snapshot
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @return map[string]interface{}*/
-func (a *SnapshotControllerApiService) GetCurrentSnapshotUsingGET(ctx context.Context, account string, application string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@return map[string]interface{}*/
+func (a *SnapshotControllerApiService) GetCurrentSnapshotUsingGET(ctx context.Context, account string, application string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -50,9 +50,8 @@ func (a *SnapshotControllerApiService) GetCurrentSnapshotUsingGET(ctx context.Co
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -63,7 +62,7 @@ func (a *SnapshotControllerApiService) GetCurrentSnapshotUsingGET(ctx context.Co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -89,24 +88,23 @@ func (a *SnapshotControllerApiService) GetCurrentSnapshotUsingGET(ctx context.Co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* SnapshotControllerApiService Get snapshot history
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param account account
- @param application application
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "limit" (int32) limit
- @return []interface{}*/
-func (a *SnapshotControllerApiService) GetSnapshotHistoryUsingGET(ctx context.Context, account string, application string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param account account
+@param application application
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "limit" (int32) limit
+@return []interface{}*/
+func (a *SnapshotControllerApiService) GetSnapshotHistoryUsingGET(ctx context.Context, account string, application string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -126,7 +124,7 @@ func (a *SnapshotControllerApiService) GetSnapshotHistoryUsingGET(ctx context.Co
 		localVarQueryParams.Add("limit", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -137,7 +135,7 @@ func (a *SnapshotControllerApiService) GetSnapshotHistoryUsingGET(ctx context.Co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -163,7 +161,5 @@ func (a *SnapshotControllerApiService) GetSnapshotHistoryUsingGET(ctx context.Co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/subnet_controller_api.go
+++ b/gateapi/subnet_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,20 +27,19 @@ var (
 
 type SubnetControllerApiService service
 
-
 /* SubnetControllerApiService Retrieve a list of subnets for a given cloud provider
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param cloudProvider cloudProvider
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return []interface{}*/
-func (a *SubnetControllerApiService) AllByCloudProviderUsingGET1(ctx context.Context, cloudProvider string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param cloudProvider cloudProvider
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return []interface{}*/
+func (a *SubnetControllerApiService) AllByCloudProviderUsingGET1(ctx context.Context, cloudProvider string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -55,7 +55,7 @@ func (a *SubnetControllerApiService) AllByCloudProviderUsingGET1(ctx context.Con
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -66,7 +66,7 @@ func (a *SubnetControllerApiService) AllByCloudProviderUsingGET1(ctx context.Con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -95,7 +95,5 @@ func (a *SubnetControllerApiService) AllByCloudProviderUsingGET1(ctx context.Con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/task_controller_api.go
+++ b/gateapi/task_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,18 +27,17 @@ var (
 
 type TaskControllerApiService service
 
-
 /* TaskControllerApiService Cancel task
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *TaskControllerApiService) CancelTaskUsingPUT1(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *TaskControllerApiService) CancelTaskUsingPUT1(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -48,9 +48,8 @@ func (a *TaskControllerApiService) CancelTaskUsingPUT1(ctx context.Context, id s
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -61,7 +60,7 @@ func (a *TaskControllerApiService) CancelTaskUsingPUT1(ctx context.Context, id s
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -87,21 +86,20 @@ func (a *TaskControllerApiService) CancelTaskUsingPUT1(ctx context.Context, id s
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* TaskControllerApiService Cancel tasks
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param ids ids
- @return map[string]interface{}*/
-func (a *TaskControllerApiService) CancelTasksUsingPUT(ctx context.Context, ids []string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param ids ids
+@return map[string]interface{}*/
+func (a *TaskControllerApiService) CancelTasksUsingPUT(ctx context.Context, ids []string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -111,10 +109,9 @@ func (a *TaskControllerApiService) CancelTasksUsingPUT(ctx context.Context, ids 
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	localVarQueryParams.Add("ids", parameterToString(ids, "multi"))
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -125,7 +122,7 @@ func (a *TaskControllerApiService) CancelTasksUsingPUT(ctx context.Context, ids 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -151,21 +148,20 @@ func (a *TaskControllerApiService) CancelTasksUsingPUT(ctx context.Context, ids 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* TaskControllerApiService Delete task
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *TaskControllerApiService) DeleteTaskUsingDELETE(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *TaskControllerApiService) DeleteTaskUsingDELETE(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -176,9 +172,8 @@ func (a *TaskControllerApiService) DeleteTaskUsingDELETE(ctx context.Context, id
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -189,7 +184,7 @@ func (a *TaskControllerApiService) DeleteTaskUsingDELETE(ctx context.Context, id
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -215,24 +210,23 @@ func (a *TaskControllerApiService) DeleteTaskUsingDELETE(ctx context.Context, id
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* TaskControllerApiService Get task details
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param taskDetailsId taskDetailsId
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xRateLimitApp" (string) X-RateLimit-App
- @return map[string]interface{}*/
-func (a *TaskControllerApiService) GetTaskDetailsUsingGET1(ctx context.Context, id string, taskDetailsId string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param taskDetailsId taskDetailsId
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xRateLimitApp" (string) X-RateLimit-App
+@return map[string]interface{}*/
+func (a *TaskControllerApiService) GetTaskDetailsUsingGET1(ctx context.Context, id string, taskDetailsId string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -249,7 +243,7 @@ func (a *TaskControllerApiService) GetTaskDetailsUsingGET1(ctx context.Context, 
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -260,7 +254,7 @@ func (a *TaskControllerApiService) GetTaskDetailsUsingGET1(ctx context.Context, 
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -289,21 +283,20 @@ func (a *TaskControllerApiService) GetTaskDetailsUsingGET1(ctx context.Context, 
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* TaskControllerApiService Get task
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return map[string]interface{}*/
-func (a *TaskControllerApiService) GetTaskUsingGET1(ctx context.Context, id string) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return map[string]interface{}*/
+func (a *TaskControllerApiService) GetTaskUsingGET1(ctx context.Context, id string) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -314,9 +307,8 @@ func (a *TaskControllerApiService) GetTaskUsingGET1(ctx context.Context, id stri
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -327,7 +319,7 @@ func (a *TaskControllerApiService) GetTaskUsingGET1(ctx context.Context, id stri
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -353,21 +345,20 @@ func (a *TaskControllerApiService) GetTaskUsingGET1(ctx context.Context, id stri
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* TaskControllerApiService Create task
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param map_ map
- @return map[string]interface{}*/
-func (a *TaskControllerApiService) TaskUsingPOST1(ctx context.Context, map_ interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param map_ map
+@return map[string]interface{}*/
+func (a *TaskControllerApiService) TaskUsingPOST1(ctx context.Context, map_ interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -377,9 +368,8 @@ func (a *TaskControllerApiService) TaskUsingPOST1(ctx context.Context, map_ inte
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -390,7 +380,7 @@ func (a *TaskControllerApiService) TaskUsingPOST1(ctx context.Context, map_ inte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -418,7 +408,5 @@ func (a *TaskControllerApiService) TaskUsingPOST1(ctx context.Context, map_ inte
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/user.go
+++ b/gateapi/user.go
@@ -10,7 +10,6 @@
 package swagger
 
 type User struct {
-
 	AccountNonExpired bool `json:"accountNonExpired,omitempty"`
 
 	Roles []string `json:"roles,omitempty"`

--- a/gateapi/v2_canary_config_controller_api.go
+++ b/gateapi/v2_canary_config_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,20 +27,19 @@ var (
 
 type V2CanaryConfigControllerApiService service
 
-
 /* V2CanaryConfigControllerApiService Create a canary configuration
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param config config
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "configurationAccountName" (string) configurationAccountName
- @return interface{}*/
-func (a *V2CanaryConfigControllerApiService) CreateCanaryConfigUsingPOST(ctx context.Context, config interface{}, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param config config
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "configurationAccountName" (string) configurationAccountName
+@return interface{}*/
+func (a *V2CanaryConfigControllerApiService) CreateCanaryConfigUsingPOST(ctx context.Context, config interface{}, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -57,7 +57,7 @@ func (a *V2CanaryConfigControllerApiService) CreateCanaryConfigUsingPOST(ctx con
 		localVarQueryParams.Add("configurationAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -68,7 +68,7 @@ func (a *V2CanaryConfigControllerApiService) CreateCanaryConfigUsingPOST(ctx con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -96,22 +96,21 @@ func (a *V2CanaryConfigControllerApiService) CreateCanaryConfigUsingPOST(ctx con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryConfigControllerApiService Delete a canary configuration
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "configurationAccountName" (string) configurationAccountName
- @return */
-func (a *V2CanaryConfigControllerApiService) DeleteCanaryConfigUsingDELETE(ctx context.Context, id string, localVarOptionals map[string]interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "configurationAccountName" (string) configurationAccountName
+@return */
+func (a *V2CanaryConfigControllerApiService) DeleteCanaryConfigUsingDELETE(ctx context.Context, id string, localVarOptionals map[string]interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -130,7 +129,7 @@ func (a *V2CanaryConfigControllerApiService) DeleteCanaryConfigUsingDELETE(ctx c
 		localVarQueryParams.Add("configurationAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -141,7 +140,7 @@ func (a *V2CanaryConfigControllerApiService) DeleteCanaryConfigUsingDELETE(ctx c
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -167,18 +166,18 @@ func (a *V2CanaryConfigControllerApiService) DeleteCanaryConfigUsingDELETE(ctx c
 }
 
 /* V2CanaryConfigControllerApiService Retrieve a canary configuration by id
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "configurationAccountName" (string) configurationAccountName
- @return interface{}*/
-func (a *V2CanaryConfigControllerApiService) GetCanaryConfigUsingGET(ctx context.Context, id string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "configurationAccountName" (string) configurationAccountName
+@return interface{}*/
+func (a *V2CanaryConfigControllerApiService) GetCanaryConfigUsingGET(ctx context.Context, id string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -197,7 +196,7 @@ func (a *V2CanaryConfigControllerApiService) GetCanaryConfigUsingGET(ctx context
 		localVarQueryParams.Add("configurationAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -208,7 +207,7 @@ func (a *V2CanaryConfigControllerApiService) GetCanaryConfigUsingGET(ctx context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -234,23 +233,22 @@ func (a *V2CanaryConfigControllerApiService) GetCanaryConfigUsingGET(ctx context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryConfigControllerApiService Retrieve a list of canary configurations
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "application" (string) application
-     @param "configurationAccountName" (string) configurationAccountName
- @return []interface{}*/
-func (a *V2CanaryConfigControllerApiService) GetCanaryConfigsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "application" (string) application
+    @param "configurationAccountName" (string) configurationAccountName
+@return []interface{}*/
+func (a *V2CanaryConfigControllerApiService) GetCanaryConfigsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -274,7 +272,7 @@ func (a *V2CanaryConfigControllerApiService) GetCanaryConfigsUsingGET(ctx contex
 		localVarQueryParams.Add("configurationAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -285,7 +283,7 @@ func (a *V2CanaryConfigControllerApiService) GetCanaryConfigsUsingGET(ctx contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -311,24 +309,23 @@ func (a *V2CanaryConfigControllerApiService) GetCanaryConfigsUsingGET(ctx contex
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryConfigControllerApiService Update a canary configuration
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param config config
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "configurationAccountName" (string) configurationAccountName
- @return interface{}*/
-func (a *V2CanaryConfigControllerApiService) UpdateCanaryConfigUsingPUT(ctx context.Context, config interface{}, id string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param config config
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "configurationAccountName" (string) configurationAccountName
+@return interface{}*/
+func (a *V2CanaryConfigControllerApiService) UpdateCanaryConfigUsingPUT(ctx context.Context, config interface{}, id string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Put")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -347,7 +344,7 @@ func (a *V2CanaryConfigControllerApiService) UpdateCanaryConfigUsingPUT(ctx cont
 		localVarQueryParams.Add("configurationAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -358,7 +355,7 @@ func (a *V2CanaryConfigControllerApiService) UpdateCanaryConfigUsingPUT(ctx cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -386,7 +383,5 @@ func (a *V2CanaryConfigControllerApiService) UpdateCanaryConfigUsingPUT(ctx cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/v2_canary_controller_api.go
+++ b/gateapi/v2_canary_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,21 +27,20 @@ var (
 
 type V2CanaryControllerApiService service
 
-
 /* V2CanaryControllerApiService (DEPRECATED) Retrieve a canary result
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param canaryConfigId canaryConfigId
- @param canaryExecutionId canaryExecutionId
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "storageAccountName" (string) storageAccountName
- @return interface{}*/
-func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET(ctx context.Context, canaryConfigId string, canaryExecutionId string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param canaryConfigId canaryConfigId
+@param canaryExecutionId canaryExecutionId
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "storageAccountName" (string) storageAccountName
+@return interface{}*/
+func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET(ctx context.Context, canaryConfigId string, canaryExecutionId string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -60,7 +60,7 @@ func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET(ctx context.Conte
 		localVarQueryParams.Add("storageAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -71,7 +71,7 @@ func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET(ctx context.Conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -97,23 +97,22 @@ func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET(ctx context.Conte
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryControllerApiService Retrieve a canary result
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param canaryExecutionId canaryExecutionId
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "storageAccountName" (string) storageAccountName
- @return interface{}*/
-func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET1(ctx context.Context, canaryExecutionId string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param canaryExecutionId canaryExecutionId
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "storageAccountName" (string) storageAccountName
+@return interface{}*/
+func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET1(ctx context.Context, canaryExecutionId string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -132,7 +131,7 @@ func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET1(ctx context.Cont
 		localVarQueryParams.Add("storageAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -143,7 +142,7 @@ func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET1(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -169,25 +168,24 @@ func (a *V2CanaryControllerApiService) GetCanaryResultUsingGET1(ctx context.Cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryControllerApiService Retrieve a list of an application&#39;s canary results
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param application application
- @param limit limit
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "statuses" (string) Comma-separated list of statuses, e.g.: RUNNING, SUCCEEDED, TERMINAL
-     @param "storageAccountName" (string) storageAccountName
- @return []interface{}*/
-func (a *V2CanaryControllerApiService) GetCanaryResultsByApplicationUsingGET(ctx context.Context, application string, limit int32, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param application application
+@param limit limit
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "statuses" (string) Comma-separated list of statuses, e.g.: RUNNING, SUCCEEDED, TERMINAL
+    @param "storageAccountName" (string) storageAccountName
+@return []interface{}*/
+func (a *V2CanaryControllerApiService) GetCanaryResultsByApplicationUsingGET(ctx context.Context, application string, limit int32, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -213,7 +211,7 @@ func (a *V2CanaryControllerApiService) GetCanaryResultsByApplicationUsingGET(ctx
 		localVarQueryParams.Add("storageAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -224,7 +222,7 @@ func (a *V2CanaryControllerApiService) GetCanaryResultsByApplicationUsingGET(ctx
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -250,23 +248,22 @@ func (a *V2CanaryControllerApiService) GetCanaryResultsByApplicationUsingGET(ctx
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryControllerApiService Retrieve a metric set pair list
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param metricSetPairListId metricSetPairListId
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "storageAccountName" (string) storageAccountName
- @return []interface{}*/
-func (a *V2CanaryControllerApiService) GetMetricSetPairListUsingGET(ctx context.Context, metricSetPairListId string, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param metricSetPairListId metricSetPairListId
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "storageAccountName" (string) storageAccountName
+@return []interface{}*/
+func (a *V2CanaryControllerApiService) GetMetricSetPairListUsingGET(ctx context.Context, metricSetPairListId string, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -285,7 +282,7 @@ func (a *V2CanaryControllerApiService) GetMetricSetPairListUsingGET(ctx context.
 		localVarQueryParams.Add("storageAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -296,7 +293,7 @@ func (a *V2CanaryControllerApiService) GetMetricSetPairListUsingGET(ctx context.
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -322,28 +319,27 @@ func (a *V2CanaryControllerApiService) GetMetricSetPairListUsingGET(ctx context.
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryControllerApiService Start a canary execution
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param canaryConfigId canaryConfigId
- @param executionRequest executionRequest
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "application" (string) application
-     @param "configurationAccountName" (string) configurationAccountName
-     @param "metricsAccountName" (string) metricsAccountName
-     @param "parentPipelineExecutionId" (string) parentPipelineExecutionId
-     @param "storageAccountName" (string) storageAccountName
- @return interface{}*/
-func (a *V2CanaryControllerApiService) InitiateCanaryUsingPOST(ctx context.Context, canaryConfigId string, executionRequest interface{}, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param canaryConfigId canaryConfigId
+@param executionRequest executionRequest
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "application" (string) application
+    @param "configurationAccountName" (string) configurationAccountName
+    @param "metricsAccountName" (string) metricsAccountName
+    @param "parentPipelineExecutionId" (string) parentPipelineExecutionId
+    @param "storageAccountName" (string) storageAccountName
+@return interface{}*/
+func (a *V2CanaryControllerApiService) InitiateCanaryUsingPOST(ctx context.Context, canaryConfigId string, executionRequest interface{}, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -386,7 +382,7 @@ func (a *V2CanaryControllerApiService) InitiateCanaryUsingPOST(ctx context.Conte
 		localVarQueryParams.Add("storageAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -397,7 +393,7 @@ func (a *V2CanaryControllerApiService) InitiateCanaryUsingPOST(ctx context.Conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -425,26 +421,25 @@ func (a *V2CanaryControllerApiService) InitiateCanaryUsingPOST(ctx context.Conte
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryControllerApiService Start a canary execution with the supplied canary config
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param adhocExecutionRequest adhocExecutionRequest
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "application" (string) application
-     @param "metricsAccountName" (string) metricsAccountName
-     @param "parentPipelineExecutionId" (string) parentPipelineExecutionId
-     @param "storageAccountName" (string) storageAccountName
- @return interface{}*/
-func (a *V2CanaryControllerApiService) InitiateCanaryWithConfigUsingPOST(ctx context.Context, adhocExecutionRequest interface{}, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param adhocExecutionRequest adhocExecutionRequest
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "application" (string) application
+    @param "metricsAccountName" (string) metricsAccountName
+    @param "parentPipelineExecutionId" (string) parentPipelineExecutionId
+    @param "storageAccountName" (string) storageAccountName
+@return interface{}*/
+func (a *V2CanaryControllerApiService) InitiateCanaryWithConfigUsingPOST(ctx context.Context, adhocExecutionRequest interface{}, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -480,7 +475,7 @@ func (a *V2CanaryControllerApiService) InitiateCanaryWithConfigUsingPOST(ctx con
 		localVarQueryParams.Add("storageAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -491,7 +486,7 @@ func (a *V2CanaryControllerApiService) InitiateCanaryWithConfigUsingPOST(ctx con
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -519,20 +514,19 @@ func (a *V2CanaryControllerApiService) InitiateCanaryWithConfigUsingPOST(ctx con
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryControllerApiService Retrieve a list of configured Kayenta accounts
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *V2CanaryControllerApiService) ListCredentialsUsingGET(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *V2CanaryControllerApiService) ListCredentialsUsingGET(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -542,9 +536,8 @@ func (a *V2CanaryControllerApiService) ListCredentialsUsingGET(ctx context.Conte
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -555,7 +548,7 @@ func (a *V2CanaryControllerApiService) ListCredentialsUsingGET(ctx context.Conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -581,20 +574,19 @@ func (a *V2CanaryControllerApiService) ListCredentialsUsingGET(ctx context.Conte
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryControllerApiService Retrieve a list of all configured canary judges
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *V2CanaryControllerApiService) ListJudgesUsingGET(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *V2CanaryControllerApiService) ListJudgesUsingGET(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -604,9 +596,8 @@ func (a *V2CanaryControllerApiService) ListJudgesUsingGET(ctx context.Context) (
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -617,7 +608,7 @@ func (a *V2CanaryControllerApiService) ListJudgesUsingGET(ctx context.Context) (
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -643,23 +634,22 @@ func (a *V2CanaryControllerApiService) ListJudgesUsingGET(ctx context.Context) (
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2CanaryControllerApiService Retrieve a list of descriptors for use in populating the canary config ui
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "filter" (string) filter
-     @param "metricsAccountName" (string) metricsAccountName
- @return []interface{}*/
-func (a *V2CanaryControllerApiService) ListMetricsServiceMetadataUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "filter" (string) filter
+    @param "metricsAccountName" (string) metricsAccountName
+@return []interface{}*/
+func (a *V2CanaryControllerApiService) ListMetricsServiceMetadataUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -683,7 +673,7 @@ func (a *V2CanaryControllerApiService) ListMetricsServiceMetadataUsingGET(ctx co
 		localVarQueryParams.Add("metricsAccountName", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -694,7 +684,7 @@ func (a *V2CanaryControllerApiService) ListMetricsServiceMetadataUsingGET(ctx co
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -720,7 +710,5 @@ func (a *V2CanaryControllerApiService) ListMetricsServiceMetadataUsingGET(ctx co
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/v2_pipeline_templates_controller_api.go
+++ b/gateapi/v2_pipeline_templates_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,19 +27,18 @@ var (
 
 type V2PipelineTemplatesControllerApiService service
 
-
 /* V2PipelineTemplatesControllerApiService (ALPHA) Create a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param pipelineTemplate pipelineTemplate
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "tag" (string) tag
- @return */
-func (a *V2PipelineTemplatesControllerApiService) CreateUsingPOST1(ctx context.Context, pipelineTemplate interface{}, localVarOptionals map[string]interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param pipelineTemplate pipelineTemplate
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "tag" (string) tag
+@return */
+func (a *V2PipelineTemplatesControllerApiService) CreateUsingPOST1(ctx context.Context, pipelineTemplate interface{}, localVarOptionals map[string]interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -56,7 +56,7 @@ func (a *V2PipelineTemplatesControllerApiService) CreateUsingPOST1(ctx context.C
 		localVarQueryParams.Add("tag", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -67,7 +67,7 @@ func (a *V2PipelineTemplatesControllerApiService) CreateUsingPOST1(ctx context.C
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -95,20 +95,20 @@ func (a *V2PipelineTemplatesControllerApiService) CreateUsingPOST1(ctx context.C
 }
 
 /* V2PipelineTemplatesControllerApiService Delete a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "application" (string) application
-     @param "digest" (string) digest
-     @param "tag" (string) tag
- @return map[string]interface{}*/
-func (a *V2PipelineTemplatesControllerApiService) DeleteUsingDELETE1(ctx context.Context, id string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "application" (string) application
+    @param "digest" (string) digest
+    @param "tag" (string) tag
+@return map[string]interface{}*/
+func (a *V2PipelineTemplatesControllerApiService) DeleteUsingDELETE1(ctx context.Context, id string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Delete")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -139,7 +139,7 @@ func (a *V2PipelineTemplatesControllerApiService) DeleteUsingDELETE1(ctx context
 		localVarQueryParams.Add("tag", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -150,7 +150,7 @@ func (a *V2PipelineTemplatesControllerApiService) DeleteUsingDELETE1(ctx context
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -176,24 +176,23 @@ func (a *V2PipelineTemplatesControllerApiService) DeleteUsingDELETE1(ctx context
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2PipelineTemplatesControllerApiService (ALPHA) Get a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "digest" (string) digest
-     @param "tag" (string) tag
- @return map[string]interface{}*/
-func (a *V2PipelineTemplatesControllerApiService) GetUsingGET2(ctx context.Context, id string, localVarOptionals map[string]interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "digest" (string) digest
+    @param "tag" (string) tag
+@return map[string]interface{}*/
+func (a *V2PipelineTemplatesControllerApiService) GetUsingGET2(ctx context.Context, id string, localVarOptionals map[string]interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -218,7 +217,7 @@ func (a *V2PipelineTemplatesControllerApiService) GetUsingGET2(ctx context.Conte
 		localVarQueryParams.Add("tag", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -229,7 +228,7 @@ func (a *V2PipelineTemplatesControllerApiService) GetUsingGET2(ctx context.Conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -255,21 +254,20 @@ func (a *V2PipelineTemplatesControllerApiService) GetUsingGET2(ctx context.Conte
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2PipelineTemplatesControllerApiService (ALPHA) List all pipelines that implement a pipeline template
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @return []interface{}*/
-func (a *V2PipelineTemplatesControllerApiService) ListPipelineTemplateDependentsUsingGET1(ctx context.Context, id string) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@return []interface{}*/
+func (a *V2PipelineTemplatesControllerApiService) ListPipelineTemplateDependentsUsingGET1(ctx context.Context, id string) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -280,9 +278,8 @@ func (a *V2PipelineTemplatesControllerApiService) ListPipelineTemplateDependents
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -293,7 +290,7 @@ func (a *V2PipelineTemplatesControllerApiService) ListPipelineTemplateDependents
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -319,22 +316,21 @@ func (a *V2PipelineTemplatesControllerApiService) ListPipelineTemplateDependents
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2PipelineTemplatesControllerApiService (ALPHA) List pipeline templates.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "scopes" ([]string) scopes
- @return []interface{}*/
-func (a *V2PipelineTemplatesControllerApiService) ListUsingGET1(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "scopes" ([]string) scopes
+@return []interface{}*/
+func (a *V2PipelineTemplatesControllerApiService) ListUsingGET1(ctx context.Context, localVarOptionals map[string]interface{}) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -344,12 +340,11 @@ func (a *V2PipelineTemplatesControllerApiService) ListUsingGET1(ctx context.Cont
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	if localVarTempParam, localVarOk := localVarOptionals["scopes"].([]string); localVarOk {
 		localVarQueryParams.Add("scopes", parameterToString(localVarTempParam, "multi"))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -360,7 +355,7 @@ func (a *V2PipelineTemplatesControllerApiService) ListUsingGET1(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -386,22 +381,21 @@ func (a *V2PipelineTemplatesControllerApiService) ListUsingGET1(ctx context.Cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2PipelineTemplatesControllerApiService List pipeline templates with versions
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "scopes" ([]string) scopes
- @return interface{}*/
-func (a *V2PipelineTemplatesControllerApiService) ListVersionsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "scopes" ([]string) scopes
+@return interface{}*/
+func (a *V2PipelineTemplatesControllerApiService) ListVersionsUsingGET(ctx context.Context, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -411,12 +405,11 @@ func (a *V2PipelineTemplatesControllerApiService) ListVersionsUsingGET(ctx conte
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	if localVarTempParam, localVarOk := localVarOptionals["scopes"].([]string); localVarOk {
 		localVarQueryParams.Add("scopes", parameterToString(localVarTempParam, "multi"))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -427,7 +420,7 @@ func (a *V2PipelineTemplatesControllerApiService) ListVersionsUsingGET(ctx conte
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -453,21 +446,20 @@ func (a *V2PipelineTemplatesControllerApiService) ListVersionsUsingGET(ctx conte
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2PipelineTemplatesControllerApiService (ALPHA) Plan a pipeline template configuration.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param pipeline pipeline
- @return map[string]interface{}*/
-func (a *V2PipelineTemplatesControllerApiService) PlanUsingPOST(ctx context.Context, pipeline interface{}) (map[string]interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param pipeline pipeline
+@return map[string]interface{}*/
+func (a *V2PipelineTemplatesControllerApiService) PlanUsingPOST(ctx context.Context, pipeline interface{}) (map[string]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  map[string]interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     map[string]interface{}
 	)
 
 	// create path and map variables
@@ -477,9 +469,8 @@ func (a *V2PipelineTemplatesControllerApiService) PlanUsingPOST(ctx context.Cont
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -490,7 +481,7 @@ func (a *V2PipelineTemplatesControllerApiService) PlanUsingPOST(ctx context.Cont
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -518,24 +509,23 @@ func (a *V2PipelineTemplatesControllerApiService) PlanUsingPOST(ctx context.Cont
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* V2PipelineTemplatesControllerApiService (ALPHA) Update a pipeline template.
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param id id
- @param pipelineTemplate pipelineTemplate
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "skipPlanDependents" (bool) skipPlanDependents
-     @param "tag" (string) tag
- @return */
-func (a *V2PipelineTemplatesControllerApiService) UpdateUsingPOST1(ctx context.Context, id string, pipelineTemplate interface{}, localVarOptionals map[string]interface{}) ( *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param id id
+@param pipelineTemplate pipelineTemplate
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "skipPlanDependents" (bool) skipPlanDependents
+    @param "tag" (string) tag
+@return */
+func (a *V2PipelineTemplatesControllerApiService) UpdateUsingPOST1(ctx context.Context, id string, pipelineTemplate interface{}, localVarOptionals map[string]interface{}) (*http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
 	)
 
 	// create path and map variables
@@ -560,7 +550,7 @@ func (a *V2PipelineTemplatesControllerApiService) UpdateUsingPOST1(ctx context.C
 		localVarQueryParams.Add("tag", parameterToString(localVarTempParam, ""))
 	}
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -571,7 +561,7 @@ func (a *V2PipelineTemplatesControllerApiService) UpdateUsingPOST1(ctx context.C
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -597,4 +587,3 @@ func (a *V2PipelineTemplatesControllerApiService) UpdateUsingPOST1(ctx context.C
 
 	return localVarHttpResponse, err
 }
-

--- a/gateapi/version.go
+++ b/gateapi/version.go
@@ -10,6 +10,5 @@
 package swagger
 
 type Version struct {
-
 	Version string `json:"version,omitempty"`
 }

--- a/gateapi/version_controller_api.go
+++ b/gateapi/version_controller_api.go
@@ -10,12 +10,13 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -25,17 +26,16 @@ var (
 
 type VersionControllerApiService service
 
-
 /* VersionControllerApiService Fetch Gate&#39;s current version
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return Version*/
-func (a *VersionControllerApiService) GetVersionUsingGET(ctx context.Context) (Version,  *http.Response, error) {
+func (a *VersionControllerApiService) GetVersionUsingGET(ctx context.Context) (Version, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  Version
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     Version
 	)
 
 	// create path and map variables
@@ -45,9 +45,8 @@ func (a *VersionControllerApiService) GetVersionUsingGET(ctx context.Context) (V
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -58,7 +57,7 @@ func (a *VersionControllerApiService) GetVersionUsingGET(ctx context.Context) (V
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -84,7 +83,5 @@ func (a *VersionControllerApiService) GetVersionUsingGET(ctx context.Context) (V
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/gateapi/webhook_controller_api.go
+++ b/gateapi/webhook_controller_api.go
@@ -10,13 +10,14 @@
 package swagger
 
 import (
-	"io/ioutil"
-	"net/url"
-	"net/http"
-	"strings"
-	"golang.org/x/net/context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
 )
 
 // Linger please
@@ -26,17 +27,16 @@ var (
 
 type WebhookControllerApiService service
 
-
 /* WebhookControllerApiService Retrieve a list of preconfigured webhooks in Orca
  * @param ctx context.Context for authentication, logging, tracing, etc.
  @return []interface{}*/
-func (a *WebhookControllerApiService) PreconfiguredWebhooksUsingGET(ctx context.Context) ([]interface{},  *http.Response, error) {
+func (a *WebhookControllerApiService) PreconfiguredWebhooksUsingGET(ctx context.Context) ([]interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Get")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  []interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     []interface{}
 	)
 
 	// create path and map variables
@@ -46,9 +46,8 @@ func (a *WebhookControllerApiService) PreconfiguredWebhooksUsingGET(ctx context.
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{  }
+	localVarHttpContentTypes := []string{}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -59,7 +58,7 @@ func (a *WebhookControllerApiService) PreconfiguredWebhooksUsingGET(ctx context.
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -85,26 +84,25 @@ func (a *WebhookControllerApiService) PreconfiguredWebhooksUsingGET(ctx context.
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
 
 /* WebhookControllerApiService Endpoint for posting webhooks to Spinnaker&#39;s webhook service
- * @param ctx context.Context for authentication, logging, tracing, etc.
- @param source source
- @param type_ type
- @param optional (nil or map[string]interface{}) with one or more of:
-     @param "xEventKey" (string) X-Event-Key
-     @param "xHubSignature" (string) X-Hub-Signature
-     @param "event" (interface{}) event
- @return interface{}*/
-func (a *WebhookControllerApiService) WebhooksUsingPOST(ctx context.Context, source string, type_ string, localVarOptionals map[string]interface{}) (interface{},  *http.Response, error) {
+* @param ctx context.Context for authentication, logging, tracing, etc.
+@param source source
+@param type_ type
+@param optional (nil or map[string]interface{}) with one or more of:
+    @param "xEventKey" (string) X-Event-Key
+    @param "xHubSignature" (string) X-Hub-Signature
+    @param "event" (interface{}) event
+@return interface{}*/
+func (a *WebhookControllerApiService) WebhooksUsingPOST(ctx context.Context, source string, type_ string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
-	 	successPayload  interface{}
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -124,7 +122,7 @@ func (a *WebhookControllerApiService) WebhooksUsingPOST(ctx context.Context, sou
 	}
 
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -135,7 +133,7 @@ func (a *WebhookControllerApiService) WebhooksUsingPOST(ctx context.Context, sou
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -171,7 +169,5 @@ func (a *WebhookControllerApiService) WebhooksUsingPOST(ctx context.Context, sou
 		return successPayload, localVarHttpResponse, err
 	}
 
-
 	return successPayload, localVarHttpResponse, err
 }
-

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	cloud.google.com/go v0.45.1 // indirect
+	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
@@ -11,6 +12,7 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/posener/complete v1.2.1 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b

--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,11 @@ require (
 	github.com/posener/complete v1.2.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
-	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
-	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20190910064555-bbd175535a8b // indirect
 	google.golang.org/appengine v1.6.2 // indirect
-	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/client-go v11.0.0+incompatible
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/posener/complete v1.2.1 // indirect
 	github.com/spf13/cobra v0.0.5
-	github.com/spf13/pflag v1.0.3
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbf
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
+github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -22,6 +24,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
@@ -55,6 +58,11 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -73,12 +81,15 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5w=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6DI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
@@ -87,7 +98,10 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -185,8 +199,11 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -96,6 +97,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90Pveol
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5 h1:58fnuSXlxZmFdJyvtTFVmVhcMLU6v5fEb/ok4wyqtNU=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -116,8 +119,8 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c h1:uOCk1iQW6Vc18bnC13MfzScl+
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190909003024-a7b16738d86b h1:XfVGCX+0T4WOStkaOsJRllbsiImhB2jgVBGc9L0lPGc=
-golang.org/x/net v0.0.0-20190909003024-a7b16738d86b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
@@ -157,6 +160,7 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0 h1:Dh6fw+p6FyRl5x/FvNswO1ji0lIGzm3KP8Y9VkS9PTE=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -183,9 +187,13 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	if err := cmd.Execute(os.Stdout); err != nil {
+	if err := cmd.NewCmdRoot(os.Stdout, os.Stderr).Execute(); err != nil {
 		if util.UI != nil {
 			util.UI.Error(err.Error())
 		} else {

--- a/main.go
+++ b/main.go
@@ -19,13 +19,16 @@ import (
 	"os"
 
 	"github.com/spinnaker/spin/cmd"
-	"github.com/spinnaker/spin/util"
+	"github.com/spinnaker/spin/cmd/assembler"
 )
 
 func main() {
-	if err := cmd.NewCmdRoot(os.Stdout, os.Stderr).Execute(); err != nil {
-		if util.UI != nil {
-			util.UI.Error(err.Error())
+	command, options := cmd.NewCmdRoot(os.Stdout, os.Stderr)
+	assembler.AddSubCommands(command, options)
+
+	if err := command.Execute(); err != nil {
+		if options.Ui != nil {
+			options.Ui.Error(err.Error())
 		} else {
 			fmt.Fprintf(os.Stderr, "\n%v\n", err)
 		}

--- a/util/cli_ui.go
+++ b/util/cli_ui.go
@@ -55,11 +55,7 @@ func InitUI(quiet, color bool, outputFormat *output.OutputFormat) {
 			ErrorWriter: os.Stderr,
 		},
 		Quiet: quiet,
-	}
-	var err error
-	UI.OutputFormat, err = output.ParseOutputFormat(outputFormat)
-	if err != nil {
-		panic(err)
+		OutputFormat: outputFormat,
 	}
 }
 

--- a/util/cli_ui.go
+++ b/util/cli_ui.go
@@ -35,21 +35,21 @@ type ColorizeUi struct {
 	InfoColor    string
 	ErrorColor   string
 	WarnColor    string
+	SuccessColor string
 	Ui           cli.Ui
 	Quiet        bool
 	OutputFormat *output.OutputFormat
 }
 
 var UI *ColorizeUi
-var hasColor bool
 
-func InitUI(quiet, color bool, outputFormat string) {
-	hasColor = color
+func InitUI(quiet, color bool, outputFormat *output.OutputFormat) {
 	UI = &ColorizeUi{
 		Colorize:   Colorize(),
 		ErrorColor: "[red]",
 		WarnColor:  "[yellow]",
 		InfoColor:  "[blue]",
+		SuccessColor:  "[bold][green]",
 		Ui: &cli.BasicUi{
 			Writer:      os.Stdout,
 			ErrorWriter: os.Stderr,
@@ -140,6 +140,12 @@ func (u *ColorizeUi) parseJsonPath(input interface{}, template string) (*bytes.B
 	}
 
 	return buf, nil
+}
+
+func (u *ColorizeUi) Success(message string) {
+	if !u.Quiet {
+		u.Ui.Info(u.colorize(message, u.SuccessColor))
+	}
 }
 
 func (u *ColorizeUi) Info(message string) {

--- a/util/cli_ui.go
+++ b/util/cli_ui.go
@@ -87,7 +87,8 @@ func (u *ColorizeUi) Output(message string) {
 // JsonOutput pretty prints the data specified in the input.
 // Callers can optionally supply a jsonpath template to pull out nested data in input.
 // This leverages the kubernetes jsonpath libs (https://kubernetes.io/docs/reference/kubectl/jsonpath/).
-func (u *ColorizeUi) JsonOutput(input interface{}, outputFormat *output.OutputFormat) {
+func (u *ColorizeUi) JsonOutput(input interface{}) {
+	outputFormat := UI.OutputFormat
 	if outputFormat != nil {
 		template := outputFormat.JsonPath
 		if template != "" {

--- a/util/cli_ui.go
+++ b/util/cli_ui.go
@@ -16,12 +16,18 @@ package util
 
 import (
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/colorstring"
 	"github.com/spinnaker/spin/cmd/output"
 )
+
+type Ui interface {
+	Success(message string)
+	JsonOutput(data interface{})
+	cli.Ui
+}
 
 type ColorizeUi struct {
 	Colorize       *colorstring.Colorize
@@ -37,8 +43,12 @@ type ColorizeUi struct {
 
 var UI *ColorizeUi
 
-func InitUI(quiet, color bool, outputFormater output.OutputFormater) {
-	UI = &ColorizeUi{
+func NewUI(
+	quiet, color bool,
+	outputFormater output.OutputFormater,
+	outWriter, errWriter io.Writer,
+) *ColorizeUi {
+	return &ColorizeUi{
 		Colorize: &colorstring.Colorize{
 			Colors:  colorstring.DefaultColors,
 			Disable: !color,
@@ -49,8 +59,8 @@ func InitUI(quiet, color bool, outputFormater output.OutputFormater) {
 		InfoColor:    "[blue]",
 		SuccessColor: "[bold][green]",
 		Ui: &cli.BasicUi{
-			Writer:      os.Stdout,
-			ErrorWriter: os.Stderr,
+			Writer:      outWriter,
+			ErrorWriter: errWriter,
 		},
 		Quiet:          quiet,
 		OutputFormater: outputFormater,

--- a/util/cli_ui.go
+++ b/util/cli_ui.go
@@ -45,7 +45,11 @@ var UI *ColorizeUi
 
 func InitUI(quiet, color bool, outputFormat *output.OutputFormat) {
 	UI = &ColorizeUi{
-		Colorize:   Colorize(),
+		Colorize: &colorstring.Colorize{
+			Colors:  colorstring.DefaultColors,
+			Disable: !color,
+			Reset:   true,
+		},
 		ErrorColor: "[red]",
 		WarnColor:  "[yellow]",
 		InfoColor:  "[blue]",
@@ -56,15 +60,6 @@ func InitUI(quiet, color bool, outputFormat *output.OutputFormat) {
 		},
 		Quiet: quiet,
 		OutputFormat: outputFormat,
-	}
-}
-
-// Colorize initializes the ui colorization.
-func Colorize() *colorstring.Colorize {
-	return &colorstring.Colorize{
-		Colors:  colorstring.DefaultColors,
-		Disable: !hasColor,
-		Reset:   true,
 	}
 }
 

--- a/util/json_reader.go
+++ b/util/json_reader.go
@@ -15,9 +15,12 @@
 package util
 
 import (
-	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"os"
+
+	"sigs.k8s.io/yaml"
 )
 
 func ParseJsonFromFileOrStdin(filePath string, tolerateEmptyStdin bool) (map[string]interface{}, error) {
@@ -48,9 +51,14 @@ func ParseJsonFromFileOrStdin(filePath string, tolerateEmptyStdin bool) (map[str
 		return nil, err
 	}
 
-	err = json.NewDecoder(fromFile).Decode(&jsonContent)
+	byteValue, err := ioutil.ReadAll(fromFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to read file: %v", err)
+	}
+
+	err = yaml.UnmarshalStrict(byteValue, &jsonContent)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal: %v", err)
 	}
 	return jsonContent, nil
 }
@@ -86,9 +94,14 @@ func ParseJsonFromFile(filePath string, tolerateEmptyInput bool) (map[string]int
 		return nil, err
 	}
 
-	err = json.NewDecoder(fromFile).Decode(&jsonContent)
+	byteValue, err := ioutil.ReadAll(fromFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed to read file: %v", err)
+	}
+
+	err = yaml.UnmarshalStrict(byteValue, &jsonContent)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal: %v", err)
 	}
 	return jsonContent, nil
 }

--- a/util/test_helpers.go
+++ b/util/test_helpers.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/spinnaker/spin/cmd/output"
 	"github.com/spf13/cobra"
+	"github.com/spinnaker/spin/cmd/output"
 )
 
 func TestGateMuxWithVersionHandler() *http.ServeMux {
@@ -33,13 +33,13 @@ func NewRootCmdForTest() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
 	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
 	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
-	InitUI(false, false, &output.OutputFormat{Json: true})
+	InitUI(false, false, output.MarshalToJson)
 	return rootCmd
 }
 
 // ExecCmdForTest executes the command and returns the STDOUT as a string.
 func ExecCmdForTest(cmd *cobra.Command) (string, error) {
-	buffer := bytes.NewBufferString("")
+	buffer := new(bytes.Buffer)
 	cmd.SetOut(buffer)
 	err := cmd.Execute()
 	out, bufferErr := ioutil.ReadAll(buffer)

--- a/util/test_helpers.go
+++ b/util/test_helpers.go
@@ -1,14 +1,9 @@
 package util
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-
-	"github.com/spf13/cobra"
-	"github.com/spinnaker/spin/cmd/output"
 )
 
 func TestGateMuxWithVersionHandler() *http.ServeMux {
@@ -22,29 +17,4 @@ func TestGateMuxWithVersionHandler() *http.ServeMux {
 	}))
 
 	return mux
-}
-
-func NewRootCmdForTest() *cobra.Command {
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
-	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
-	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
-	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
-	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
-	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
-	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
-	InitUI(false, false, output.MarshalToJson)
-	return rootCmd
-}
-
-// ExecCmdForTest executes the command and returns the STDOUT as a string.
-func ExecCmdForTest(cmd *cobra.Command) (string, error) {
-	buffer := new(bytes.Buffer)
-	cmd.SetOut(buffer)
-	err := cmd.Execute()
-	out, bufferErr := ioutil.ReadAll(buffer)
-	if bufferErr != nil {
-		return "", fmt.Errorf("Failed to read command output buffer: %v", err)
-	}
-	return string(out), err
 }

--- a/util/test_helpers.go
+++ b/util/test_helpers.go
@@ -1,9 +1,15 @@
 package util
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/andreyvit/diff"
 )
 
 func TestGateMuxWithVersionHandler() *http.ServeMux {
@@ -17,4 +23,42 @@ func TestGateMuxWithVersionHandler() *http.ServeMux {
 	}))
 
 	return mux
+}
+
+// TestPrettyJsonDiff compares prettified json against an expected json string.
+// Leading and trailing whitespace is trimmed before the comparison.
+func TestPrettyJsonDiff(t *testing.T, description, expected string, recieved []byte) {
+	pretty := new(bytes.Buffer)
+	err := json.Indent(pretty, recieved, "", " ")
+	if err != nil {
+		t.Fatalf("Failed to pretify %s: %v\n%s", description, err, string(recieved))
+	}
+	recievedPretty := strings.TrimSpace(pretty.String())
+	if expected != recievedPretty {
+		t.Fatalf("Unexpected %s:\n%s", description, diff.LineDiff(expected, recievedPretty))
+	}
+}
+
+// NewTestBufferHandlerFunc returns an http.Handler which buffers the request
+// body, writes the response header, and writes the response body. Requests
+// that do not match the specified method recieve 404 Not Found.
+func NewTestBufferHandlerFunc(method string, requestBuffer io.Writer, responseHeader int, responseBody string) http.Handler {
+	buffer := requestBuffer
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != method {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		defer r.Body.Close()
+		_, err := io.Copy(buffer, r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to copy body to buffer: %v", err), http.StatusInternalServerError)
+			return
+		}
+
+		// Empty response body. Status: 200 Success
+		w.WriteHeader(responseHeader)
+		fmt.Fprintln(w, responseBody)
+	})
 }

--- a/util/test_helpers.go
+++ b/util/test_helpers.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/spinnaker/spin/cmd/output"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +33,7 @@ func NewRootCmdForTest() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
 	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
 	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
-	InitUI(false, false, "")
+	InitUI(false, false, &output.OutputFormat{Json: true})
 	return rootCmd
 }
 

--- a/util/test_helpers.go
+++ b/util/test_helpers.go
@@ -1,9 +1,13 @@
 package util
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+
+	"github.com/spf13/cobra"
 )
 
 func TestGateMuxWithVersionHandler() *http.ServeMux {
@@ -17,4 +21,29 @@ func TestGateMuxWithVersionHandler() *http.ServeMux {
 	}))
 
 	return mux
+}
+
+func NewRootCmdForTest() *cobra.Command {
+	rootCmd := &cobra.Command{}
+	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.spin/config)")
+	rootCmd.PersistentFlags().String("gate-endpoint", "", "Gate (API server) endpoint. Default http://localhost:8084")
+	rootCmd.PersistentFlags().Bool("insecure", false, "Ignore Certificate Errors")
+	rootCmd.PersistentFlags().Bool("quiet", false, "Squelch non-essential output")
+	rootCmd.PersistentFlags().Bool("no-color", false, "Disable color")
+	rootCmd.PersistentFlags().String("output", "", "Configure output formatting")
+	rootCmd.PersistentFlags().String("default-headers", "", "Configure additional headers for gate client requests")
+	InitUI(false, false, "")
+	return rootCmd
+}
+
+// ExecCmdForTest executes the command and returns the STDOUT as a string.
+func ExecCmdForTest(cmd *cobra.Command) (string, error) {
+	buffer := bytes.NewBufferString("")
+	cmd.SetOut(buffer)
+	err := cmd.Execute()
+	out, bufferErr := ioutil.ReadAll(buffer)
+	if bufferErr != nil {
+		return "", fmt.Errorf("Failed to read command output buffer: %v", err)
+	}
+	return string(out), err
 }


### PR DESCRIPTION
JSON may be what Spinnaker's API uses, but it's tedious to write manually and harder for humans to read and manage. So I added YAML support in the CLI to covert back and forth easily. This way we can store our Spinnaker pipeline configs in YAML and do GitOps, the same way we do for Kubernetes manifests.

- Overload --output command to support --output yaml
- Replace json parser with yaml parser (json is a subset of yaml)
- Use Kubernetes' yaml parser, which converts through JSON to support annotations
- Enable strict parsing mode (dissallow duplicate map keys. better error messages)
- Wrap some error messages with more context

Tests were broken after I enabled strict parsing, so I had to modify the pipeline-template plan tests so stop using a duplicate map key to test an invalid config. I changed it to an unknown key instead. After this, I all the tests passed, using the yaml parser.

I also did some cleanup of the codebase while I was in there (go fmt, goimports, test command refactor). If it makes review harder, you can look at each commit separately.

While manually testing, I realized that. `--output yaml` was tedious to type, so i added `-o` as a shortcut. While doing do, I also realized the app save subcommand was missing some common shorts, so I added `-a` for `--application-name` and `-f` for `--file`.