### PR TITLE
refactor base gate http client to be usable outside spin cli

### DIFF
--- a/config/auth/authconfig.go
+++ b/config/auth/authconfig.go
@@ -25,12 +25,13 @@ import (
 
 // Config is the CLI's authentication configuration.
 type Config struct {
-	Enabled bool           `yaml:"enabled"`
-	X509    *x509.Config   `yaml:"x509,omitempty"`
-	OAuth2  *oauth2.Config `yaml:"oauth2,omitempty"`
-	Basic   *basic.Config  `yaml:"basic,omitempty"`
-	Iap     *config.Config `yaml:"iap,omitempty"`
-	Ldap    *ldap.Config   `yaml:"ldap,omitempty"`
+	Enabled          bool           `yaml:"enabled"`
+	IgnoreCertErrors bool           `yaml:"ignoreCertErrors"`
+	X509             *x509.Config   `yaml:"x509,omitempty"`
+	OAuth2           *oauth2.Config `yaml:"oauth2,omitempty"`
+	Basic            *basic.Config  `yaml:"basic,omitempty"`
+	Iap              *config.Config `yaml:"iap,omitempty"`
+	Ldap             *ldap.Config   `yaml:"ldap,omitempty"`
 
 	GoogleServiceAccount *gsa.Config `yaml:"google_service_account,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.1 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5w=


### PR DESCRIPTION
Hey all, I am working on a [spinnaker managed delivery tool](https://github.com/Spinnaker/md-lib-go) where I was hoping to reuse the ~/.spin/config file and authentication code that is in this project.  This PR tries to untangle the http client authentication code from the cli/flags setup so that it can be used independently.

I don't believe there are any functional changes for the `spin` project, just moving some of the code around and creating a few more exported functions.

This is currently how I am using this code:
https://github.com/spinnaker/md-lib-go/blob/master/cmd/spinmd/main.go#L41

I am open to any suggestions.  Thanks!