### PR TITLE
test(account/get): use jsondiff to compare responses

### DIFF
--- a/cmd/account/get_test.go
+++ b/cmd/account/get_test.go
@@ -17,6 +17,7 @@ package account
 import (
 	"bytes"
 	"fmt"
+	"github.com/nsf/jsondiff"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -59,7 +60,11 @@ func TestAccountGet_json(t *testing.T) {
 	expected := strings.TrimSpace(accountJson)
 	recieved := strings.TrimSpace(buffer.String())
 	if expected != recieved {
-		t.Fatalf("Unexpected command output:\n%s", diff.LineDiff(expected, recieved))
+		opts := jsondiff.DefaultJSONOptions()
+		eq, d := jsondiff.Compare([]byte(expected), []byte(recieved), &opts)
+		if eq != jsondiff.FullMatch {
+			t.Fatalf("Unexpected command output:\n%s", d)
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.1 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
+github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
gateapi 1.21.x autogenerated code from swagger will return json payload with the keys sorted differently. This is to address that issue