### PR TITLE
Add save project command

### DIFF
--- a/cmd/project/project.go
+++ b/cmd/project/project.go
@@ -29,5 +29,6 @@ func NewProjectCmd(rootOptions *cmd.RootOptions) *cobra.Command {
 
 	// create subcommands
 	cmd.AddCommand(NewGetCmd(options))
+	cmd.AddCommand(NewSaveCmd(options))
 	return cmd
 }

--- a/cmd/project/save.go
+++ b/cmd/project/save.go
@@ -1,0 +1,92 @@
+package project
+
+import (
+    "errors"
+    "fmt"
+
+    "github.com/spf13/cobra"
+    orca_tasks "github.com/spinnaker/spin/cmd/orca-tasks"
+    "github.com/spinnaker/spin/util"
+)
+
+type saveOptions struct {
+    *projectOptions
+    projectFile string
+    projectName string
+    ownerEmail      string
+}
+
+var (
+    saveProjectShort = "Save the provided project"
+    saveOrojectLong  = "Save the specified project"
+)
+
+func NewSaveCmd(prjOptions *projectOptions) *cobra.Command {
+    options := &saveOptions{
+        projectOptions: prjOptions,
+    }
+    cmd := &cobra.Command{
+        Use:   "save",
+        Short: saveProjectShort,
+        Long:  saveOrojectLong,
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return saveProject(cmd, options)
+        },
+    }
+    cmd.PersistentFlags().StringVarP(&options.projectFile, "file", "f", "", "path to the project file")
+    cmd.PersistentFlags().StringVarP(&options.projectName, "name", "n", "", "name of the project")
+    cmd.PersistentFlags().StringVarP(&options.ownerEmail, "email", "e", "", "email of the project owner")
+
+    return cmd
+}
+
+func saveProject(cmd *cobra.Command, options *saveOptions) error {
+    // TODO: check for existing project
+
+    initialProject, err := util.ParseJsonFromFileOrStdin(options.projectFile, true)
+    if err != nil {
+        return fmt.Errorf("Could not parse supplied project: %v.\n", err)
+    }
+
+    var project map[string]interface{}
+    if initialProject != nil && len(initialProject) > 0 {
+        project = initialProject
+        if options.projectName != "" {
+            options.Ui.Warn("Overriding project name with explicit flag values.\n")
+            project["name"] = options.projectName
+        }
+        if options.ownerEmail != "" {
+            options.Ui.Warn("Overriding project owner email with explicit flag values.\n")
+            project["email"] = options.ownerEmail
+        }
+    } else {
+        if options.projectName == "" || options.ownerEmail == "" {
+            return errors.New("Required project parameters missing, exiting...")
+        }
+        project = map[string]interface{}{
+            "name":           options.projectName,
+            "email":          options.ownerEmail,
+        }
+    }
+
+    fmt.Println(project)
+    createProjectTask := map[string]interface{}{
+        "job":          []interface{}{map[string]interface{}{"type": "upsertProject", "project": project["project"], "user": project["project"]["email"]}},
+        "application":  "spinnaker",
+        "project":      project["project"]["name"],
+        "description":  fmt.Sprintf("Create Project: %s", project["name"]),
+    }
+
+    ref, _, err := options.GateClient.TaskControllerApi.TaskUsingPOST1(options.GateClient.Context, createProjectTask)
+    if err != nil {
+        return err
+    }
+
+    err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref, 5)
+    if err != nil {
+        return err
+    }
+
+    options.Ui.Success("Project save succeeded")
+    return nil
+}

--- a/cmd/project/save.go
+++ b/cmd/project/save.go
@@ -70,8 +70,9 @@ func saveProject(cmd *cobra.Command, options *saveOptions) error {
     }
 
     createProjectTask := map[string]interface{}{
-        "job":          []interface{}{map[string]interface{}{"type": "upsertProject", "project": project}},
+        "job":          []interface{}{map[string]interface{}{"type": "upsertProject", "project": project, "user":  project["email"]}},
         "application":  "spinnaker",
+        "project":  project["name"],
         "description":  fmt.Sprintf("Create Project: %s", project["name"]),
     }
 

--- a/cmd/project/save.go
+++ b/cmd/project/save.go
@@ -1,9 +1,23 @@
+// Copyright (c) 2020, Anosua Chini Mukhopadhyay
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
 package project
 
 import (
 	"errors"
 	"fmt"
-    "net/http"
+	"net/http"
 
 	"github.com/spf13/cobra"
 	orca_tasks "github.com/spinnaker/spin/cmd/orca-tasks"
@@ -70,11 +84,11 @@ func saveProject(cmd *cobra.Command, options *saveOptions) error {
 		}
 	}
 
-    projectName := fmt.Sprintf("%s", project["name"])
+	projectName := fmt.Sprintf("%s", project["name"])
 	id, err := doesProjectExist(projectName, options)
-    if id != "" {
-        project["id"] = id
-    }
+	if id != "" {
+		project["id"] = id
+	}
 
 	createProjectTask := map[string]interface{}{
 		"job":         []interface{}{map[string]interface{}{"type": "upsertProject", "project": project, "user": project["email"]}},

--- a/cmd/project/save.go
+++ b/cmd/project/save.go
@@ -1,91 +1,113 @@
 package project
 
 import (
-    "errors"
-    "fmt"
+	"errors"
+	"fmt"
+    "net/http"
 
-    "github.com/spf13/cobra"
-    orca_tasks "github.com/spinnaker/spin/cmd/orca-tasks"
-    "github.com/spinnaker/spin/util"
+	"github.com/spf13/cobra"
+	orca_tasks "github.com/spinnaker/spin/cmd/orca-tasks"
+	"github.com/spinnaker/spin/util"
 )
 
 type saveOptions struct {
-    *projectOptions
-    projectFile string
-    projectName string
-    ownerEmail      string
+	*projectOptions
+	projectFile string
+	projectName string
+	ownerEmail  string
 }
 
 var (
-    saveProjectShort = "Save the provided project"
-    saveOrojectLong  = "Save the specified project"
+	saveProjectShort = "Save the provided project"
+	saveOrojectLong  = "Save the specified project"
 )
 
 func NewSaveCmd(prjOptions *projectOptions) *cobra.Command {
-    options := &saveOptions{
-        projectOptions: prjOptions,
-    }
-    cmd := &cobra.Command{
-        Use:   "save",
-        Short: saveProjectShort,
-        Long:  saveOrojectLong,
-        RunE: func(cmd *cobra.Command, args []string) error {
-            return saveProject(cmd, options)
-        },
-    }
-    cmd.PersistentFlags().StringVarP(&options.projectFile, "file", "f", "", "path to the project file")
-    cmd.PersistentFlags().StringVarP(&options.projectName, "name", "n", "", "name of the project")
-    cmd.PersistentFlags().StringVarP(&options.ownerEmail, "email", "e", "", "email of the project owner")
+	options := &saveOptions{
+		projectOptions: prjOptions,
+	}
+	cmd := &cobra.Command{
+		Use:   "save",
+		Short: saveProjectShort,
+		Long:  saveOrojectLong,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return saveProject(cmd, options)
+		},
+	}
+	cmd.PersistentFlags().StringVarP(&options.projectFile, "file", "f", "", "path to the project file")
+	cmd.PersistentFlags().StringVarP(&options.projectName, "name", "n", "", "name of the project")
+	cmd.PersistentFlags().StringVarP(&options.ownerEmail, "email", "e", "", "email of the project owner")
 
-    return cmd
+	return cmd
 }
 
 func saveProject(cmd *cobra.Command, options *saveOptions) error {
-    // TODO: check for existing project
+	// TODO: check for existing project
 
-    initialProject, err := util.ParseJsonFromFileOrStdin(options.projectFile, true)
-    if err != nil {
-        return fmt.Errorf("Could not parse supplied project: %v.\n", err)
+	initialProject, err := util.ParseJsonFromFileOrStdin(options.projectFile, true)
+	if err != nil {
+		return fmt.Errorf("Could not parse supplied project: %v.\n", err)
+	}
+
+	var project map[string]interface{}
+	if initialProject != nil && len(initialProject) > 0 {
+		project = initialProject
+		if options.projectName != "" {
+			options.Ui.Warn("Overriding project name with explicit flag values.\n")
+			project["name"] = options.projectName
+		}
+		if options.ownerEmail != "" {
+			options.Ui.Warn("Overriding project owner email with explicit flag values.\n")
+			project["email"] = options.ownerEmail
+		}
+	} else {
+		if options.projectName == "" || options.ownerEmail == "" {
+			return errors.New("Required project parameters missing, exiting...")
+		}
+		project = map[string]interface{}{
+			"name":  options.projectName,
+			"email": options.ownerEmail,
+		}
+	}
+
+    projectName := fmt.Sprintf("%s", project["name"])
+	id, err := doesProjectExist(projectName, options)
+    if id != "" {
+        project["id"] = id
     }
 
-    var project map[string]interface{}
-    if initialProject != nil && len(initialProject) > 0 {
-        project = initialProject
-        if options.projectName != "" {
-            options.Ui.Warn("Overriding project name with explicit flag values.\n")
-            project["name"] = options.projectName
-        }
-        if options.ownerEmail != "" {
-            options.Ui.Warn("Overriding project owner email with explicit flag values.\n")
-            project["email"] = options.ownerEmail
-        }
-    } else {
-        if options.projectName == "" || options.ownerEmail == "" {
-            return errors.New("Required project parameters missing, exiting...")
-        }
-        project = map[string]interface{}{
-            "name":           options.projectName,
-            "email":          options.ownerEmail,
-        }
-    }
+	createProjectTask := map[string]interface{}{
+		"job":         []interface{}{map[string]interface{}{"type": "upsertProject", "project": project, "user": project["email"]}},
+		"application": "spinnaker",
+		"project":     projectName,
+		"description": fmt.Sprintf("Create Project: %s", projectName),
+	}
 
-    createProjectTask := map[string]interface{}{
-        "job":          []interface{}{map[string]interface{}{"type": "upsertProject", "project": project, "user":  project["email"]}},
-        "application":  "spinnaker",
-        "project":  project["name"],
-        "description":  fmt.Sprintf("Create Project: %s", project["name"]),
-    }
+	ref, _, err := options.GateClient.TaskControllerApi.TaskUsingPOST1(options.GateClient.Context, createProjectTask)
+	if err != nil {
+		return err
+	}
 
-    ref, _, err := options.GateClient.TaskControllerApi.TaskUsingPOST1(options.GateClient.Context, createProjectTask)
-    if err != nil {
-        return err
-    }
+	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref, 5)
+	if err != nil {
+		return err
+	}
 
-    err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref, 5)
-    if err != nil {
-        return err
-    }
+	options.Ui.Success("Project save succeeded")
+	return nil
+}
 
-    options.Ui.Success("Project save succeeded")
-    return nil
+func doesProjectExist(projectName string, options *saveOptions) (string, error) {
+	project, resp, err := options.GateClient.ProjectControllerApi.GetUsingGET1(options.GateClient.Context, projectName)
+	if resp != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return "", nil
+		} else if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("Encountered an error getting project, status code: %d\n", resp.StatusCode)
+		} else {
+			return fmt.Sprintf("%s", project["id"]), nil
+		}
+	}
+
+	return "", err
 }

--- a/cmd/project/save.go
+++ b/cmd/project/save.go
@@ -69,11 +69,9 @@ func saveProject(cmd *cobra.Command, options *saveOptions) error {
         }
     }
 
-    fmt.Println(project)
     createProjectTask := map[string]interface{}{
-        "job":          []interface{}{map[string]interface{}{"type": "upsertProject", "project": project["project"], "user": project["project"]["email"]}},
+        "job":          []interface{}{map[string]interface{}{"type": "upsertProject", "project": project}},
         "application":  "spinnaker",
-        "project":      project["project"]["name"],
         "description":  fmt.Sprintf("Create Project: %s", project["name"]),
     }
 

--- a/cmd/project/save_test.go
+++ b/cmd/project/save_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2020, Anosua Chini Mukhopadhyay
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package project
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	// "os"
+	"strings"
+	"testing"
+
+	"github.com/spinnaker/spin/cmd"
+	"github.com/spinnaker/spin/util"
+)
+
+const (
+	NAME              = "prj"
+	EMAIL             = "user@spinnaker.com"
+	PROJECT_TEST_FILE = "../../util/json_test_files/example_project.json"
+)
+
+func TestProjectSave_basic(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateProjectSaveSuccess(saveBuffer)
+	defer ts.Close()
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewProjectCmd(options))
+
+	args := []string{
+		"project", "save",
+		"--gate-endpoint=" + ts.URL,
+		"--name", NAME,
+		"--email", EMAIL,
+	}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(testProjectTaskJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
+}
+
+func TestProjectSave_fail(t *testing.T) {
+	ts := testGateFail()
+	defer ts.Close()
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewProjectCmd(options))
+
+	args := []string{
+		"project", "save",
+		"--gate-endpoint=" + ts.URL,
+		"--name", NAME,
+		"--email", EMAIL,
+	}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+}
+
+func TestProjectSave_flags(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateProjectSaveSuccess(saveBuffer)
+	defer ts.Close()
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewProjectCmd(options))
+
+	args := []string{
+		"project", "save",
+		"--gate-endpoint=" + ts.URL,
+	}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := ""
+	recieved := strings.TrimSpace(saveBuffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected save request body:\n%s", recieved)
+	}
+}
+
+func TestProjectSave_missingname(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateProjectSaveSuccess(saveBuffer)
+	defer ts.Close()
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewProjectCmd(options))
+
+	args := []string{
+		"project", "save",
+		"--email", EMAIL,
+	}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := ""
+	recieved := strings.TrimSpace(saveBuffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected save request body:\n%s", recieved)
+	}
+}
+
+func TestProjectSave_missingemail(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateProjectSaveSuccess(saveBuffer)
+	defer ts.Close()
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewProjectCmd(options))
+
+	args := []string{
+		"project", "save",
+		"--name", NAME,
+		"--gate-endpoint", ts.URL,
+	}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := ""
+	recieved := strings.TrimSpace(saveBuffer.String())
+	if expected != recieved {
+		t.Fatalf("Unexpected save request body:\n%s", recieved)
+	}
+}
+
+func TestProjectSave_filejson(t *testing.T) {
+	saveBuffer := new(bytes.Buffer)
+	ts := testGateProjectSaveSuccess(saveBuffer)
+	defer ts.Close()
+
+	rootCmd, options := cmd.NewCmdRoot(ioutil.Discard, ioutil.Discard)
+	rootCmd.AddCommand(NewProjectCmd(options))
+
+	args := []string{
+		"project", "save",
+		"--file", PROJECT_TEST_FILE,
+		"--gate-endpoint", ts.URL,
+	}
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("Command failed with: %s", err)
+	}
+
+	expected := strings.TrimSpace(testExpandedProjectTaskJsonStr)
+	recieved := saveBuffer.Bytes()
+	util.TestPrettyJsonDiff(t, "save request body", expected, recieved)
+}
+
+// testGateFail spins up a local http server that we will configure the GateClient
+// to direct requests to. Responds with a 500 InternalServerError.
+func testGateFail() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO(jacobkiefer): Mock more robust errors once implemented upstream.
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}))
+}
+
+// testGateProjectSaveSuccess spins up a local http server that we will configure the GateClient
+// to direct requests to. Responds with successful responses to pipeline execute API calls.
+// Writes request body to buffer for testing.
+func testGateProjectSaveSuccess(buffer io.Writer) *httptest.Server {
+	mux := util.TestGateMuxWithVersionHandler()
+	mux.Handle(
+		"/tasks",
+		util.NewTestBufferHandlerFunc(http.MethodPost, buffer, http.StatusOK, strings.TrimSpace(testAppTaskRefJsonStr)),
+	)
+	mux.Handle("/tasks/id", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.TrimSpace(testProjectTaskStatusJsonStr))
+	}))
+	return httptest.NewServer(mux)
+}
+
+const testAppTaskRefJsonStr = `
+{
+ "ref": "/tasks/id"
+}
+`
+const testProjectTaskStatusJsonStr = `
+{
+ "status": "SUCCEEDED"
+}
+`
+
+const testExpandedProjectTaskJsonStr = `
+{
+ "application": "spinnaker",
+ "description": "Create Project: example project",
+ "job": [
+  {
+   "project": {
+    "config": {
+     "applications": [],
+     "clusters": [],
+     "pipelineConfigs": []
+    },
+    "email": "user@spinnaker.com",
+    "name": "example project",
+    "user": "user@spinnaker.com"
+   },
+   "type": "upsertProject",
+   "user": "user@spinnaker.com"
+  }
+ ],
+ "project": "example project"
+}
+`
+
+const testProjectTaskJsonStr = `
+{
+ "application": "spinnaker",
+ "description": "Create Project: prj",
+ "job": [
+  {
+   "project": {
+    "email": "user@spinnaker.com",
+    "name": "prj"
+   },
+   "type": "upsertProject",
+   "user": "user@spinnaker.com"
+  }
+ ],
+ "project": "prj"
+}
+`

--- a/util/json_test_files/example_project.json
+++ b/util/json_test_files/example_project.json
@@ -1,0 +1,12 @@
+{
+   "name":"example project",
+   "email":"user@spinnaker.com",
+   "config":{
+      "pipelineConfigs":[
+      ],
+      "applications":[
+      ],
+      "clusters":[
+      ]
+   }
+}

--- a/util/json_test_files/example_project.json
+++ b/util/json_test_files/example_project.json
@@ -1,6 +1,7 @@
 {
    "name":"example project",
    "email":"user@spinnaker.com",
+   "user":"user@spinnaker.com",
    "config":{
       "pipelineConfigs":[
       ],


### PR DESCRIPTION
`spin project save --file <filename` will save a project. Setting just the name and email flags will also create a project with nothing in it. Like the `spin application save` command if you pass in a file with the name or email flags, the value passed via the flags will override what's in the file.

This PR also introduces a test for the save function, noting that all other tests for projects are missing and will be added in near future.

The corresponding sponnet changes are in this PR: https://github.com/spinnaker/sponnet/pull/11