### PR TITLE
fix(gatewayClient): retrieve gate endpoint from struct method

### DIFF
--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -130,7 +130,7 @@ func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation st
 
 	gateClient.httpClient = httpClient
 
-	updatedConfig, err := authenticateOAuth2(ui.Output, httpClient, gateEndpoint, gateClient.Config.Auth)
+	updatedConfig, err := authenticateOAuth2(ui.Output, httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
 	if err != nil {
 		ui.Error("OAuth2 Authentication failed.")
 		return nil, unwrapErr(ui, err)
@@ -141,7 +141,7 @@ func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation st
 		_ = gateClient.writeYAMLConfig()
 	}
 
-	updatedConfig, err = authenticateGoogleServiceAccount(httpClient, gateEndpoint, gateClient.Config.Auth)
+	updatedConfig, err = authenticateGoogleServiceAccount(httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Google service account authentication failed: %v", err))
 		return nil, unwrapErr(ui, err)
@@ -151,7 +151,7 @@ func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation st
 		_ = gateClient.writeYAMLConfig()
 	}
 
-	if err = authenticateLdap(ui.Output, httpClient, gateEndpoint, gateClient.Config.Auth); err != nil {
+	if err = authenticateLdap(ui.Output, httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth); err != nil {
 		ui.Error("LDAP Authentication Failed")
 		return nil, unwrapErr(ui, err)
 	}


### PR DESCRIPTION
issue: https://github.com/spinnaker/spinnaker/issues/5913

I was unable to authenticate due this line: https://github.com/spinnaker/spin/blob/master/cmd/gateclient/client.go#L134 which was due to `gateEndpoint` being an empty string value as I provide the value through `~/.spin/config` and not as cli arg.

This fix simply calls struct method `GateEndpoint` which returns arg value or the config value.