### PR TITLE
return execution id on pipeline execute command

### DIFF
--- a/cmd/pipeline/execute.go
+++ b/cmd/pipeline/execute.go
@@ -87,7 +87,7 @@ func executePipeline(cmd *cobra.Command, options *executeOptions) error {
 		}
 	}
 
-	resp, err := options.GateClient.PipelineControllerApi.InvokePipelineConfigUsingPOST1(options.GateClient.Context,
+	successPayload, resp, err := options.GateClient.PipelineControllerApi.InvokePipelineConfigUsingPOST1(options.GateClient.Context,
 		options.application,
 		options.name,
 		map[string]interface{}{"trigger": trigger})
@@ -100,7 +100,7 @@ func executePipeline(cmd *cobra.Command, options *executeOptions) error {
 		return fmt.Errorf("Encountered an error executing pipeline, status code: %d\n", resp.StatusCode)
 	}
 
-	options.Ui.Success("Pipeline execution started")
+	options.Ui.JsonOutput(successPayload)
 
 	return nil
 }

--- a/gateapi/pipeline_controller_api.go
+++ b/gateapi/pipeline_controller_api.go
@@ -578,12 +578,13 @@ func (a *PipelineControllerApiService) GetPipelineUsingGET(ctx context.Context, 
  @param optional (nil or map[string]interface{}) with one or more of:
      @param "trigger" (interface{}) trigger
  @return */
-func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx context.Context, application string, pipelineNameOrId string, localVarOptionals map[string]interface{}) ( *http.Response, error) {
+func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx context.Context, application string, pipelineNameOrId string, localVarOptionals map[string]interface{}) (interface{}, *http.Response, error) {
 	var (
 		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody interface{}
-		localVarFileName string
-		localVarFileBytes []byte
+		localVarPostBody   interface{}
+		localVarFileName   string
+		localVarFileBytes  []byte
+		successPayload     interface{}
 	)
 
 	// create path and map variables
@@ -595,9 +596,8 @@ func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx contex
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-
 	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{ "application/json",  }
+	localVarHttpContentTypes := []string{"application/json"}
 
 	// set Content-Type header
 	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
@@ -608,7 +608,7 @@ func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx contex
 	// to determine the Accept header
 	localVarHttpHeaderAccepts := []string{
 		"*/*",
-		}
+	}
 
 	// set Accept header
 	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
@@ -621,20 +621,24 @@ func (a *PipelineControllerApiService) InvokePipelineConfigUsingPOST1(ctx contex
 	}
 	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return nil, err
+		return successPayload, nil, err
 	}
 
 	localVarHttpResponse, err := a.client.callAPI(r)
 	if err != nil || localVarHttpResponse == nil {
-		return localVarHttpResponse, err
+		return successPayload, localVarHttpResponse, err
 	}
 	defer localVarHttpResponse.Body.Close()
 	if localVarHttpResponse.StatusCode >= 300 {
 		bodyBytes, _ := ioutil.ReadAll(localVarHttpResponse.Body)
-		return localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
+		return successPayload, localVarHttpResponse, reportError("Status: %v, Body: %s", localVarHttpResponse.Status, bodyBytes)
 	}
 
-	return localVarHttpResponse, err
+	if err = json.NewDecoder(localVarHttpResponse.Body).Decode(&successPayload); err != nil {
+		return successPayload, localVarHttpResponse, err
+	}
+
+	return successPayload, localVarHttpResponse, err
 }
 
 /* PipelineControllerApiService Trigger a pipeline execution


### PR DESCRIPTION
We are building a wrapper around spin cli, so if spin cli could execution id then we could use it to poll spinnaker to get the status of the pipeline. Looks like the gate api already returns the pipeline execution id but we are not returning it to user. I made a couple of changes for this to work.

before code changes
```
spin pipeline execute -a testapp -n samplemicroservice
Pipeline execution started
```

after
```
./spin pipeline execute -a testapp -n samplemicroservice
{
 "ref": "/pipelines/01EDK74BBVZ97QPWDXBYWARVH4"
}
```

I understand the code in gateapi is auto-generated using swagger, so probably something needs to be updated in gate service as well (probably here - https://github.com/spinnaker/gate/blob/master/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/PipelineController.groovy#L198). I'm not well versed with java so I'm not sure what needs to be changed there. I'm updating my code here, so that we know what needs to be changed.

This also fixes - https://github.com/spinnaker/spinnaker/issues/5657

cc: @kevinawoo 