### PR TITLE
fix(gateclient): broken gate endpoint

### DIFF
--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -141,7 +141,7 @@ func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation st
 		_ = gateClient.writeYAMLConfig()
 	}
 
-	updatedConfig, err = authenticateGoogleServiceAccount(httpClient, gateEndpoint, gateClient.Config.Auth)
+	updatedConfig, err = authenticateGoogleServiceAccount(httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Google service account authentication failed: %v", err))
 		return nil, unwrapErr(ui, err)


### PR DESCRIPTION
## What

Fix broken Gate endpoint configuration API.

## Why

The current version only reads Gate endpoint from the CLI argument and doesn't refer to the spin config`s `.gate.endpoint`. 