### PR TITLE
fix(config): broken spinconfig

### DIFF
--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -46,7 +46,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"sigs.k8s.io/yaml"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -221,7 +221,7 @@ func userConfig(gateClient *GatewayClient, configLocation string) error {
 
 	yamlFile, err := ioutil.ReadFile(gateClient.configLocation)
 	if yamlFile != nil {
-		err = yaml.UnmarshalStrict([]byte(os.ExpandEnv(string(yamlFile))), &gateClient.Config)
+		err = yaml.Unmarshal([]byte(os.ExpandEnv(string(yamlFile))), &gateClient.Config)
 		if err != nil {
 			gateClient.ui.Error(fmt.Sprintf("Could not deserialize config file with contents: %s, failing.", yamlFile))
 			return err
@@ -229,6 +229,8 @@ func userConfig(gateClient *GatewayClient, configLocation string) error {
 	} else {
 		gateClient.Config = config.Config{}
 	}
+
+	fmt.Println(gateClient.Config)
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	cloud.google.com/go v0.45.1 // indirect
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
-	github.com/antihax/optional v1.0.0
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
@@ -22,6 +21,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20190910064555-bbd175535a8b // indirect
 	google.golang.org/appengine v1.6.2 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/client-go v11.0.0+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
-github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
## What

The spin config is broken and it has no backward compatibility.  Also ran `go mod tidy`.

In current latest master version, the spin requires spin config like below:

```yaml
Auth:
    Basic: null
    Enabled: true
    GoogleServiceAccount: null
    Iap: null
    IgnoreCertErrors: false
    Ldap: null
  OAuth2:
      AuthUrl: https://xxx.com
      CachedToken:
       access_token: MASKED
        expiry: "0001-01-01T00:00:00Z"
        token_type: bearer
      ClientId: MASKED
      ClientSecret: MASKED
      Scopes:
      - openid email
      TokenUrl: https://yyy.com
    X509: null
 Gate:
   Endpoint:                                         
```


## Why

This is because spin used to use `sigs.k8s.io`'s YAML util packages.
In this package, for example, the marshal is done by first marshaling it as JSON and then marshal again to YAML.

https://github.com/kubernetes-sigs/yaml/blob/9fc95527decd95bb9d28cc2eab08179b2d0f6971/yaml.go#L15-L28

Therefore, the YAML annotations will be omitted. That's why the current spin requires and updates the spin config exactly the same as Go struct.

I've changed to use the Go native YAML package because we don't need to marshal/unmarshal to JSON