### PR TITLE
perf(updating spin config): spin config gets rechecked multiple times

### DIFF
--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -129,31 +129,37 @@ func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation st
 	}
 
 	gateClient.httpClient = httpClient
+	updatedConfig := false
+	updatedMessage := ""
 
-	updatedConfig, err := authenticateOAuth2(ui.Output, httpClient, gateEndpoint, gateClient.Config.Auth)
-	if err != nil {
-		ui.Error("OAuth2 Authentication failed.")
-		return nil, unwrapErr(ui, err)
+	if gateClient.Config.Auth.OAuth2 != nil {
+		updatedConfig, err = authenticateOAuth2(ui.Output, httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
+		if err != nil {
+			ui.Error("OAuth2 Authentication failed.")
+			return nil, unwrapErr(ui, err)
+		}
+		updatedMessage = "Caching oauth2 token."
+	}
+
+	if gateClient.Config.Auth.GoogleServiceAccount != nil {
+		updatedConfig, err = authenticateGoogleServiceAccount(httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Google service account authentication failed: %v", err))
+			return nil, unwrapErr(ui, err)
+		}
+		updatedMessage = "Caching gsa token."
 	}
 
 	if updatedConfig {
-		ui.Info("Caching oauth2 token.")
+		ui.Info(updatedMessage)
 		_ = gateClient.writeYAMLConfig()
 	}
 
-	updatedConfig, err = authenticateGoogleServiceAccount(httpClient, gateEndpoint, gateClient.Config.Auth)
-	if err != nil {
-		ui.Error(fmt.Sprintf("Google service account authentication failed: %v", err))
-		return nil, unwrapErr(ui, err)
-	}
-
-	if updatedConfig {
-		_ = gateClient.writeYAMLConfig()
-	}
-
-	if err = authenticateLdap(ui.Output, httpClient, gateEndpoint, gateClient.Config.Auth); err != nil {
-		ui.Error("LDAP Authentication Failed")
-		return nil, unwrapErr(ui, err)
+	if gateClient.Config.Auth.Ldap != nil {
+		if err = authenticateLdap(ui.Output, httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth); err != nil {
+			ui.Error("LDAP Authentication Failed")
+			return nil, unwrapErr(ui, err)
+		}
 	}
 
 	m := make(map[string]string)

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -132,23 +132,19 @@ func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation st
 	updatedConfig := false
 	updatedMessage := ""
 
-	if gateClient.Config.Auth.OAuth2 != nil {
-		updatedConfig, err = authenticateOAuth2(ui.Output, httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
-		if err != nil {
-			ui.Error("OAuth2 Authentication failed.")
-			return nil, unwrapErr(ui, err)
-		}
-		updatedMessage = "Caching oauth2 token."
+	updatedConfig, err = authenticateOAuth2(ui.Output, httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
+	if err != nil {
+		ui.Error("OAuth2 Authentication failed.")
+		return nil, unwrapErr(ui, err)
 	}
+	updatedMessage = "Caching oauth2 token."
 
-	if gateClient.Config.Auth.GoogleServiceAccount != nil {
-		updatedConfig, err = authenticateGoogleServiceAccount(httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
-		if err != nil {
-			ui.Error(fmt.Sprintf("Google service account authentication failed: %v", err))
-			return nil, unwrapErr(ui, err)
-		}
-		updatedMessage = "Caching gsa token."
+	updatedConfig, err = authenticateGoogleServiceAccount(httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Google service account authentication failed: %v", err))
+		return nil, unwrapErr(ui, err)
 	}
+	updatedMessage = "Caching gsa token."
 
 	if updatedConfig {
 		ui.Info(updatedMessage)

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -155,11 +155,9 @@ func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation st
 		_ = gateClient.writeYAMLConfig()
 	}
 
-	if gateClient.Config.Auth.Ldap != nil {
-		if err = authenticateLdap(ui.Output, httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth); err != nil {
-			ui.Error("LDAP Authentication Failed")
-			return nil, unwrapErr(ui, err)
-		}
+	if err = authenticateLdap(ui.Output, httpClient, gateClient.GateEndpoint(), gateClient.Config.Auth); err != nil {
+		ui.Error("LDAP Authentication Failed")
+		return nil, unwrapErr(ui, err)
 	}
 
 	m := make(map[string]string)


### PR DESCRIPTION
This PR touches on: https://github.com/spinnaker/spinnaker/issues/5913 which sparked the following PRs to open: https://github.com/spinnaker/spin/pull/268/files https://github.com/spinnaker/spin/pull/269 and https://github.com/spinnaker/spin/pull/263 which are all duplicates of each other. This PR has the same fix but also skips rechecking methods that weren't in the config originally.

Old behavior: If you didn't have LDAP set but cached your oauth token, your config got updated to set LDAP to null in the config. This cleans that up as well sets the appropriate update message for the other methods updates like GSA token.