### PR TITLE
chore(gateclient): use os.UserHomeDir instead of mitchellh/go-homedir

### DIFF
--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -30,12 +30,10 @@ import (
 	_ "net/http/pprof"
 	"net/url"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"syscall"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/oauth2"
@@ -210,19 +208,10 @@ func userConfig(gateClient *GatewayClient, configLocation string) error {
 	if configLocation != "" {
 		gateClient.configLocation = configLocation
 	} else {
-		userHome := ""
-		usr, err := user.Current()
+		userHome, err := os.UserHomeDir()
 		if err != nil {
-			// Fallback by trying to read $HOME
-			userHome = os.Getenv("HOME")
-			if userHome != "" {
-				err = nil
-			} else {
-				gateClient.ui.Error("Could not read current user from environment, failing.")
-				return err
-			}
-		} else {
-			userHome = usr.HomeDir
+			gateClient.ui.Error("Could not read current user home directory from environment, failing.")
+			return err
 		}
 		gateClient.configLocation = filepath.Join(userHome, ".spin", "config")
 	}
@@ -266,11 +255,11 @@ func InitializeHTTPClient(auth *auth.Config) (*http.Client, error) {
 		}
 
 		if X509.CertPath != "" && X509.KeyPath != "" {
-			certPath, err := homedir.Expand(X509.CertPath)
+			certPath, err := expandFilepath(X509.CertPath)
 			if err != nil {
 				return nil, err
 			}
-			keyPath, err := homedir.Expand(X509.KeyPath)
+			keyPath, err := expandFilepath(X509.KeyPath)
 			if err != nil {
 				return nil, err
 			}
@@ -605,4 +594,16 @@ func securePrompt(output func(string), inputMsg string) string {
 	byteSecret, _ := terminal.ReadPassword(int(syscall.Stdin))
 	secret := string(byteSecret)
 	return strings.TrimSpace(secret)
+}
+
+func expandFilepath(path string) (string, error) {
+	if !strings.HasPrefix(path, "~") {
+		return path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return home + strings.TrimPrefix(path, "~"), nil
 }

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -45,6 +45,7 @@ import (
 	"github.com/spinnaker/spin/config/auth"
 	iap "github.com/spinnaker/spin/config/auth/iap"
 	gate "github.com/spinnaker/spin/gateapi"
+	"github.com/spinnaker/spin/util"
 	"github.com/spinnaker/spin/version"
 )
 
@@ -255,11 +256,11 @@ func InitializeHTTPClient(auth *auth.Config) (*http.Client, error) {
 		}
 
 		if X509.CertPath != "" && X509.KeyPath != "" {
-			certPath, err := expandFilepath(X509.CertPath)
+			certPath, err := util.ExpandHomeDir(X509.CertPath)
 			if err != nil {
 				return nil, err
 			}
-			keyPath, err := expandFilepath(X509.KeyPath)
+			keyPath, err := util.ExpandHomeDir(X509.KeyPath)
 			if err != nil {
 				return nil, err
 			}
@@ -594,16 +595,4 @@ func securePrompt(output func(string), inputMsg string) string {
 	byteSecret, _ := terminal.ReadPassword(int(syscall.Stdin))
 	secret := string(byteSecret)
 	return strings.TrimSpace(secret)
-}
-
-func expandFilepath(path string) (string, error) {
-	if !strings.HasPrefix(path, "~") {
-		return path, nil
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return home + strings.TrimPrefix(path, "~"), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,11 @@ go 1.12
 require (
 	cloud.google.com/go v0.45.1 // indirect
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
-	github.com/antihax/optional v1.0.0
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
-github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/util/filepath.go
+++ b/util/filepath.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"os"
+	"strings"
+)
+
+// ExpandHomeDir expands filepath with a tilde prefix. If the given filepath
+// doesn't have a tilde this function return the filepath as it is.
+func ExpandHomeDir(path string) (string, error) {
+	if !strings.HasPrefix(path, "~") {
+		return path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return home + strings.TrimPrefix(path, "~"), nil
+}


### PR DESCRIPTION
Now that Go 1.12 provides `os.UserHomeDir`, this PR uses it instead of [mitchellh/go-homedir](https://github.com/mitchellh/go-homedir). Thanks to this, we can reduce third-party dependency.

## Refenrences

- https://golang.org/doc/go1.12#os