### PR TITLE
fix(format): fix format with gofmt and goimports

### DIFF
--- a/cmd/canary/canary-config/delete.go
+++ b/cmd/canary/canary-config/delete.go
@@ -57,7 +57,6 @@ func deleteCanaryConfig(cmd *cobra.Command, options *deleteOptions, args []strin
 
 	resp, err := options.GateClient.V2CanaryConfigControllerApi.DeleteCanaryConfigUsingDELETE(
 		options.GateClient.Context, id, map[string]interface{}{})
-
 	if err != nil {
 		return err
 	}

--- a/cmd/canary/canary-config/get.go
+++ b/cmd/canary/canary-config/get.go
@@ -67,7 +67,6 @@ func getCanaryConfig(cmd *cobra.Command, options *getOptions, args []string) err
 
 	successPayload, resp, err := options.GateClient.V2CanaryConfigControllerApi.GetCanaryConfigUsingGET(
 		options.GateClient.Context, id, map[string]interface{}{})
-
 	if err != nil {
 		return err
 	}

--- a/cmd/canary/canary-config/list.go
+++ b/cmd/canary/canary-config/list.go
@@ -54,7 +54,6 @@ func NewListCmd(canaryConfigOptions *canaryConfigOptions) *cobra.Command {
 func listCanaryConfig(cmd *cobra.Command, options *listOptions) error {
 	successPayload, resp, err := options.GateClient.V2CanaryConfigControllerApi.GetCanaryConfigsUsingGET(
 		options.GateClient.Context, map[string]interface{}{"application": options.application})
-
 	if err != nil {
 		return err
 	}

--- a/cmd/canary/canary-config/retro.go
+++ b/cmd/canary/canary-config/retro.go
@@ -50,9 +50,7 @@ const (
 	retroTemplateLong  = "Retro the provided canary config"
 )
 
-var (
-	retrySleepCycle = 6 * time.Second
-)
+var retrySleepCycle = 6 * time.Second
 
 func NewRetroCmd(canaryConfigOptions *canaryConfigOptions) *cobra.Command {
 	options := &retroOptions{

--- a/cmd/pipeline-template/delete.go
+++ b/cmd/pipeline-template/delete.go
@@ -66,7 +66,6 @@ func deletePipelineTemplate(cmd *cobra.Command, options *deleteOptions, args []s
 	}
 
 	_, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.DeleteUsingDELETE1(options.GateClient.Context, id, queryParams)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline-template/get.go
+++ b/cmd/pipeline-template/get.go
@@ -75,7 +75,6 @@ func getPipelineTemplate(cmd *cobra.Command, options *getOptions, args []string)
 
 	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.GetUsingGET2(options.GateClient.Context,
 		id, queryParams)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline-template/list.go
+++ b/cmd/pipeline-template/list.go
@@ -54,7 +54,6 @@ func NewListCmd(pipelineTemplateOptions *pipelineTemplateOptions) *cobra.Command
 func listPipelineTemplate(cmd *cobra.Command, options *listOptions) error {
 	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.ListUsingGET1(options.GateClient.Context,
 		map[string]interface{}{"scopes": options.scopes})
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline-template/plan.go
+++ b/cmd/pipeline-template/plan.go
@@ -63,7 +63,6 @@ func planPipelineTemplate(cmd *cobra.Command, options *planOptions) error {
 	}
 
 	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.PlanUsingPOST(options.GateClient.Context, configJson)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline-template/use_test.go
+++ b/cmd/pipeline-template/use_test.go
@@ -26,10 +26,12 @@ import (
 	"github.com/spinnaker/spin/util"
 )
 
-var testAppName = "test-application"
-var testPipelineName = "test-pipeline"
-var testDescription = "test-description"
-var testVariables = "one=1,two=2,three=3,four=4"
+var (
+	testAppName      = "test-application"
+	testPipelineName = "test-pipeline"
+	testDescription  = "test-description"
+	testVariables    = "one=1,two=2,three=3,four=4"
+)
 
 func TestPipelineTemplateUse_basic(t *testing.T) {
 	ts := testGateVersionSuccess()

--- a/cmd/pipeline/delete.go
+++ b/cmd/pipeline/delete.go
@@ -59,7 +59,6 @@ func deletePipeline(cmd *cobra.Command, options *deleteOptions) error {
 		return errors.New("one of required parameters 'application' or 'name' not set")
 	}
 	resp, err := options.GateClient.PipelineControllerApi.DeletePipelineUsingDELETE(options.GateClient.Context, options.application, options.name)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/execute.go
+++ b/cmd/pipeline/execute.go
@@ -107,7 +107,6 @@ func executePipeline(cmd *cobra.Command, options *executeOptions) error {
 		options.application,
 		options.name,
 		map[string]interface{}{"trigger": trigger})
-
 	if err != nil {
 		return fmt.Errorf("Execute pipeline failed with response: %v and error: %s\n", resp, err)
 	}

--- a/cmd/pipeline/execution/cancel.go
+++ b/cmd/pipeline/execution/cancel.go
@@ -58,7 +58,6 @@ func cancelExecution(cmd *cobra.Command, options *cancelOptions, args []string) 
 	resp, err := options.GateClient.PipelineControllerApi.CancelPipelineUsingPUT1(options.GateClient.Context,
 		executionId,
 		map[string]interface{}{})
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/execution/get.go
+++ b/cmd/pipeline/execution/get.go
@@ -60,7 +60,6 @@ func getExecution(cmd *cobra.Command, options *getOptions, args []string) error 
 
 	successPayload, resp, err := options.GateClient.ExecutionsControllerApi.GetLatestExecutionsByConfigIdsUsingGET(
 		options.GateClient.Context, query)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/execution/list.go
+++ b/cmd/pipeline/execution/list.go
@@ -95,7 +95,6 @@ func listExecution(cmd *cobra.Command, options *listOptions) error {
 
 	successPayload, resp, err := options.GateClient.ExecutionsControllerApi.GetLatestExecutionsByConfigIdsUsingGET(
 		options.GateClient.Context, query)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/execution/list_test.go
+++ b/cmd/pipeline/execution/list_test.go
@@ -42,7 +42,6 @@ func TestExecutionList_basic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Command failed with: %s", err)
 	}
-
 }
 
 func TestExecutionList_flags(t *testing.T) {

--- a/cmd/pipeline/get.go
+++ b/cmd/pipeline/get.go
@@ -61,7 +61,6 @@ func getPipeline(cmd *cobra.Command, options *getOptions) error {
 	successPayload, resp, err := options.GateClient.ApplicationControllerApi.GetPipelineConfigUsingGET(options.GateClient.Context,
 		options.application,
 		options.name)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -58,7 +58,6 @@ func listPipeline(cmd *cobra.Command, options *listOptions) error {
 	}
 
 	successPayload, resp, err := options.GateClient.ApplicationControllerApi.GetPipelineConfigsForApplicationUsingGET(options.GateClient.Context, options.application)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/save_test.go
+++ b/cmd/pipeline/save_test.go
@@ -159,6 +159,7 @@ func TestPipelineSave_accessdenied(t *testing.T) {
 		t.Fatalf("Command failed with: %s", err)
 	}
 }
+
 func TestPipelineSave_flags(t *testing.T) {
 	ts := testGateSuccess()
 	defer ts.Close()

--- a/cmd/project/save_test.go
+++ b/cmd/project/save_test.go
@@ -21,8 +21,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-
-	// "os"
 	"strings"
 	"testing"
 
@@ -210,6 +208,7 @@ const testAppTaskRefJsonStr = `
  "ref": "/tasks/id"
 }
 `
+
 const testProjectTaskStatusJsonStr = `
 {
  "status": "SUCCEEDED"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ type RootOptions struct {
 	GateClient *gateclient.GatewayClient
 }
 
-//TODO(karlkfi): Pipe stdin reader through NewCmdRoot for testing
+// TODO(karlkfi): Pipe stdin reader through NewCmdRoot for testing
 func NewCmdRoot(outWriter, errWriter io.Writer) (*cobra.Command, *RootOptions) {
 	options := &RootOptions{}
 

--- a/config/auth/iap/config.go
+++ b/config/auth/iap/config.go
@@ -14,7 +14,7 @@
 
 package config
 
-//Config mapping to the config file for IAP
+// Config mapping to the config file for IAP
 type Config struct {
 	OAuthClientId         string `yaml:"oauthClientId"`
 	OAuthClientSecret     string `yaml:"oauthClientSecret"`

--- a/config/auth/iap/oauth.go
+++ b/config/auth/iap/oauth.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -25,8 +26,6 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
-	"context"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -38,10 +37,8 @@ const (
 	serverStateTokenLen = 60
 )
 
-var (
-	// Configure the default request scopes, this can be overriden
-	oauthScopes = []string{oauthEmailScope}
-)
+// Configure the default request scopes, this can be overriden
+var oauthScopes = []string{oauthEmailScope}
 
 // Creates a new iapOAuthResponse object
 type iapOAuthResponse struct {
@@ -72,7 +69,6 @@ func (o *oauthReceiver) killWhenReady(n net.Conn, s http.ConnState) {
 
 // NewOAuthConfig creates a new OAuth config
 func (o *oauthReceiver) NewOAuthConfig() *oauth2.Config {
-
 	return &oauth2.Config{
 		ClientID:     o.clientId,
 		ClientSecret: o.clientSecret,
@@ -188,7 +184,7 @@ func RequestIapIDToken(token string, clientId string, clientSecret string, iapCl
 	}
 
 	// Create a one time response struct
-	var oauthResponse = &iapOAuthResponse{}
+	oauthResponse := &iapOAuthResponse{}
 	// Decode the response
 	err = json.NewDecoder(resp.Body).Decode(&oauthResponse)
 	if err != nil {

--- a/gateapi/api_client.go
+++ b/gateapi/api_client.go
@@ -242,7 +242,6 @@ func (c *APIClient) prepareRequest(
 	formParams url.Values,
 	fileName string,
 	fileBytes []byte) (localVarRequest *http.Request, err error) {
-
 	var body *bytes.Buffer
 
 	// Detect postBody type and post.

--- a/gateapi/api_response.go
+++ b/gateapi/api_response.go
@@ -31,13 +31,11 @@ type APIResponse struct {
 }
 
 func NewAPIResponse(r *http.Response) *APIResponse {
-
 	response := &APIResponse{Response: r}
 	return response
 }
 
 func NewAPIResponseWithError(errorMessage string) *APIResponse {
-
 	response := &APIResponse{Message: errorMessage}
 	return response
 }

--- a/util/execcmd/execcmd_linux.go
+++ b/util/execcmd/execcmd_linux.go
@@ -18,7 +18,7 @@ import (
 	"os/exec"
 )
 
-//open the application with parameters
+// open the application with parameters
 func OpenUrl(url string) error {
 	return exec.Command("xdg-open", url).Run()
 }

--- a/util/execcmd/execcmd_windows.go
+++ b/util/execcmd/execcmd_windows.go
@@ -18,7 +18,7 @@ import (
 	"os/exec"
 )
 
-//open the application with parameters
+// open the application with parameters
 func OpenUrl(url string) error {
 	return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Run()
 }


### PR DESCRIPTION
This PR fixes the format by running `gofmt -w -s .` and `goimports -w -local github.com/spinnaker/spin .` and manually updating some of them to keep the codebase consistent and follow the convention.