### PR TITLE
feat(golang-cli): ignore swagger generated code in gateapi/

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 run:
   modules-download-mode: readonly
+  skip-dirs:
+      - gateapi
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
the code in `/gateapi` is autogenerated by swagger. There's not a really good reason to enforce any kind of linting in there.