### PR TITLE
fix(projectSave) if pipeline id is sent in json, set project id to that

### DIFF
--- a/cmd/project/save.go
+++ b/cmd/project/save.go
@@ -87,7 +87,7 @@ func saveProject(cmd *cobra.Command, options *saveOptions) error {
 
 	projectName := fmt.Sprintf("%s", project["name"])
 	id, err := doesProjectExist(projectName, options)
-	if id != "" {
+	if id != "" && project["id"] == nil {
 		project["id"] = id
 	}
 


### PR DESCRIPTION
Addressing https://github.com/spinnaker/spinnaker/issues/3651#issuecomment-665491856 -> if project id is sent, the project will be saved with that ID sent to it.