### PR TITLE
fix(pipelineTemplateSave): fix returning error on existing pipeline template saving

### DIFF
--- a/cmd/pipeline-template/save.go
+++ b/cmd/pipeline-template/save.go
@@ -117,7 +117,7 @@ func savePipelineTemplate(cmd *cobra.Command, options *saveOptions) error {
 		return saveErr
 	}
 
-	if saveResp.StatusCode != http.StatusAccepted {
+	if saveResp.StatusCode != http.StatusAccepted && saveResp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Encountered an error saving pipeline template %v, status code: %d\n",
 			templateJson,
 			saveResp.StatusCode)


### PR DESCRIPTION
See issue: https://github.com/spinnaker/spinnaker/issues/6008

Recent changes to pipeline template saving did not take into account saving existing pipeline templates and will return an error without the status check fixed.