### PR TITLE
fix(pipelineTemplateSave): fix tests for saving pipeline template

### DIFF
--- a/cmd/pipeline-template/save_test.go
+++ b/cmd/pipeline-template/save_test.go
@@ -309,7 +309,7 @@ func testGatePipelineTemplateUpdateSuccess(buffer io.Writer) *httptest.Server {
 	mux := util.TestGateMuxWithVersionHandler()
 	mux.Handle(
 		"/v2/pipelineTemplates/update/testSpelTemplate",
-		util.NewTestBufferHandlerFunc(http.MethodPost, buffer, http.StatusAccepted, ""),
+		util.NewTestBufferHandlerFunc(http.MethodPost, buffer, http.StatusOK, ""),
 	)
 	// Return that we found an MPT to signal that we should update.
 	mux.Handle("/v2/pipelineTemplates/testSpelTemplate", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is to fix the test for the issues mentioned in: https://github.com/spinnaker/spin/pull/298

This addresses github issues https://github.com/spinnaker/spinnaker/issues/6008 and part of https://github.com/spinnaker/spinnaker/issues/6003#issuecomment-685791703

I've confirmed that the test fails properly without the fix in PR 298 and passes correctly with the fix in.