### PR TITLE
fix(azureOauth2): fixed oauth2 auth for azure custom config support

### DIFF
--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -519,10 +519,15 @@ func login(httpClient *http.Client, endpoint string, accessToken string) error {
 		return err
 	}
 	loginReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
-	_, err = httpClient.Do(loginReq) // Login to establish session.
+	resp, err := httpClient.Do(loginReq) // Login to establish session.
 	if err != nil {
 		return errors.Errorf("login failed %s", err)
 	}
+
+	if resp.StatusCode != 200 {
+		return errors.Errorf("login failed %s", resp.Status)
+	}
+
 	return nil
 }
 

--- a/config/auth/oauth2/config.go
+++ b/config/auth/oauth2/config.go
@@ -21,12 +21,13 @@ import (
 // Config is the configuration for using OAuth2.0 to
 // authenticate with Spinnaker
 type Config struct {
-	TokenUrl     string        `yaml:"tokenUrl"`
-	AuthUrl      string        `yaml:"authUrl"`
-	ClientId     string        `yaml:"clientId"`
-	ClientSecret string        `yaml:"clientSecret"`
-	Scopes       []string      `yaml:"scopes"`
-	CachedToken  *oauth2.Token `yaml:"cachedToken,omitempty"`
+	TokenUrl        string            `yaml:"tokenUrl"`
+	AuthUrl         string            `yaml:"authUrl"`
+	ClientId        string            `yaml:"clientId"`
+	ClientSecret    string            `yaml:"clientSecret"`
+	AuthCodeOptions map[string]string `yaml:"authCodeOptions,omitempty"`
+	Scopes          []string          `yaml:"scopes"`
+	CachedToken     *oauth2.Token     `yaml:"cachedToken,omitempty"`
 }
 
 func (x *Config) IsValid() bool {

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -35,6 +35,11 @@ auth:
     scopes:
       - scope1
       - scope2
+    # To set Oauth AuthCodeOptions, follow the following format. Auzre Oauth2 API needs this
+    # see https://pkg.go.dev/golang.org/x/oauth2#AuthCodeOption
+    AuthCodeOptions:
+      access_type: online
+      prompt: none
 
     # To set a cached token, follow the following format:
     # note that these yaml keys must match the golang struct tags exactly because of yaml.UnmarshalStrict

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.1 // indirect


### PR DESCRIPTION
Updated the oauth2 to work with azure oauth2 custom config, Added support for AuthCodeOptions options in config.
Updated the auth workflow to open default browser with auth url.  No need to copy past url and code from oauth2 redirect response.
If the default browser doesn't work this fallbacks to printing url on console with instruction.