### PR TITLE
chose(dep): Upgrade go version to 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.13
+        go-version: 1.15
     - uses: actions/cache@v2
       with:
         path: ~/go/pkg/mod

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spinnaker/spin
 
-go 1.12
+go 1.15
 
 require (
 	cloud.google.com/go v0.45.1 // indirect


### PR DESCRIPTION
Upgraded the Go version to [`1.15`](https://golang.org/doc/go1.15) and fixed the use of different versions in CI.
