### PR TITLE
refactor(cmd): Clean up value checks

### DIFF
--- a/cmd/account/get.go
+++ b/cmd/account/get.go
@@ -61,9 +61,12 @@ func getAccount(cmd *cobra.Command, options *getOptions, args []string) error {
 
 	account, resp, err := options.GateClient.CredentialsControllerApi.GetAccountUsingGET(options.GateClient.Context, accountName, &gate.CredentialsControllerApiGetAccountUsingGETOpts{})
 	if resp != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// pass
+		case http.StatusNotFound:
 			return fmt.Errorf("Account '%s' not found\n", accountName)
-		} else if resp.StatusCode != http.StatusOK {
+		default:
 			return fmt.Errorf("Encountered an error getting account, status code: %d\n", resp.StatusCode)
 		}
 	}

--- a/cmd/application/get.go
+++ b/cmd/application/get.go
@@ -67,9 +67,12 @@ func getApplication(cmd *cobra.Command, options *getOptions, args []string) erro
 
 	app, resp, err := options.GateClient.ApplicationControllerApi.GetApplicationUsingGET(options.GateClient.Context, applicationName, &gate.ApplicationControllerApiGetApplicationUsingGETOpts{Expand: optional.NewBool(options.expand)})
 	if resp != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// pass
+		case http.StatusNotFound:
 			return fmt.Errorf("Application '%s' not found\n", applicationName)
-		} else if resp.StatusCode != http.StatusOK {
+		default:
 			return fmt.Errorf("Encountered an error getting application, status code: %d\n", resp.StatusCode)
 		}
 	}

--- a/cmd/canary/canary-config/retro.go
+++ b/cmd/canary/canary-config/retro.go
@@ -186,7 +186,7 @@ func retroCanaryConfig(cmd *cobra.Command, options *retroOptions) error {
 	complete := canaryResult.(map[string]interface{})["complete"].(bool)
 
 	retries := 0
-	for retries < 10 && complete == false && canaryResultErr == nil {
+	for retries < 10 && !complete && canaryResultErr == nil {
 		canaryResult, canaryResultResp, canaryResultErr = options.GateClient.V2CanaryControllerApi.GetCanaryResultUsingGET1(options.GateClient.Context, canaryExecutionId, queryOptionalParams)
 		complete = canaryResult.(map[string]interface{})["complete"].(bool)
 		time.Sleep(retrySleepCycle)
@@ -195,7 +195,8 @@ func retroCanaryConfig(cmd *cobra.Command, options *retroOptions) error {
 
 	if canaryResultErr != nil {
 		return canaryResultErr
-	} else if complete == false {
+	}
+	if !complete {
 		return fmt.Errorf(
 			"Canary execution %s incomplete after 60 seconds, aborting", canaryExecutionId)
 	}

--- a/cmd/canary/canary-config/save.go
+++ b/cmd/canary/canary-config/save.go
@@ -74,13 +74,14 @@ func saveCanaryConfig(cmd *cobra.Command, options *saveOptions) error {
 
 	var saveResp *http.Response
 	var saveErr error
-	if resp.StatusCode == http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK:
 		_, saveResp, saveErr = options.GateClient.V2CanaryConfigControllerApi.UpdateCanaryConfigUsingPUT(
 			options.GateClient.Context, templateJson, templateId, &gate.V2CanaryConfigControllerApiUpdateCanaryConfigUsingPUTOpts{})
-	} else if resp.StatusCode == http.StatusNotFound {
+	case http.StatusNotFound:
 		_, saveResp, saveErr = options.GateClient.V2CanaryConfigControllerApi.CreateCanaryConfigUsingPOST(
 			options.GateClient.Context, templateJson, &gate.V2CanaryConfigControllerApiCreateCanaryConfigUsingPOSTOpts{})
-	} else {
+	default:
 		if queryErr != nil {
 			return queryErr
 		}

--- a/cmd/pipeline-template/save.go
+++ b/cmd/pipeline-template/save.go
@@ -91,21 +91,23 @@ func savePipelineTemplate(cmd *cobra.Command, options *saveOptions) error {
 	var saveResp *http.Response
 	var saveRet map[string]interface{}
 	var saveErr error
-	if resp.StatusCode == http.StatusOK {
+
+	switch resp.StatusCode {
+	case http.StatusOK:
 		opt := &gate.V2PipelineTemplatesControllerApiUpdateUsingPOST1Opts{}
 		if options.tag != "" {
 			opt.Tag = optional.NewString(options.tag)
 		}
 
 		saveRet, saveResp, saveErr = options.GateClient.V2PipelineTemplatesControllerApi.UpdateUsingPOST1(options.GateClient.Context, templateId, templateJson, opt)
-	} else if resp.StatusCode == http.StatusNotFound {
+	case http.StatusNotFound:
 		opt := &gate.V2PipelineTemplatesControllerApiCreateUsingPOST1Opts{}
 		if options.tag != "" {
 			opt.Tag = optional.NewString(options.tag)
 		}
 
 		saveRet, saveResp, saveErr = options.GateClient.V2PipelineTemplatesControllerApi.CreateUsingPOST1(options.GateClient.Context, templateJson, opt)
-	} else {
+	default:
 		if queryErr != nil {
 			return queryErr
 		}

--- a/cmd/pipeline/update.go
+++ b/cmd/pipeline/update.go
@@ -86,11 +86,12 @@ func updatePipeline(cmd *cobra.Command, options *updateOptions) error {
 
 	// TODO: support option passing in and remove nil in below call
 	opt := &gate.PipelineControllerApiSavePipelineUsingPOSTOpts{}
-	saveResp, saveErr := options.GateClient.PipelineControllerApi.SavePipelineUsingPOST(options.GateClient.Context, foundPipeline, opt)
+	saveResp, err := options.GateClient.PipelineControllerApi.SavePipelineUsingPOST(options.GateClient.Context, foundPipeline, opt)
+	if err != nil {
+		return err
+	}
 
-	if saveErr != nil {
-		return saveErr
-	} else if saveResp.StatusCode != http.StatusOK {
+	if saveResp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Encountered an error saving pipeline, status code: %d\n", saveResp.StatusCode)
 	}
 


### PR DESCRIPTION
## What

Removed unnecessary control flows and tidied up some blocks. The behavior wouldn't be changed.

## Why

To improve readability and maintainability and allow more users to easily contribute to this project.
