### PR TITLE
feat(applicationPipelines): ability to get execution IDs of pipelines under an application and cancel some or all with reasons

### DIFF
--- a/cmd/application/application.go
+++ b/cmd/application/application.go
@@ -33,5 +33,6 @@ func NewApplicationCmd(rootOptions *cmd.RootOptions) *cobra.Command {
 	cmd.AddCommand(NewListCmd(options))
 	cmd.AddCommand(NewDeleteCmd(options))
 	cmd.AddCommand(NewSaveCmd(options))
+	cmd.AddCommand(NewPipelineCmd(options))
 	return cmd
 }

--- a/cmd/application/cancel_pipeline.go
+++ b/cmd/application/cancel_pipeline.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2020, Anosua "Chini" Mukhopadhyay
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package application
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/antihax/optional"
+	"github.com/spf13/cobra"
+
+	gate "github.com/spinnaker/spin/gateapi"
+)
+
+type cancelPipelineOptions struct {
+	*pipelineOptions
+	id     string
+	reason string
+}
+
+var (
+	cancelPipelinesShort   = "Cancel the pipeline for the specified pipeline execution id"
+	cancelPipelinesLong    = "Cancel the pipeline for the specified pipeline execution id"
+	cancelPipelinesExample = "usage: spin application pipelines cancel [options] id reason"
+)
+
+func NewCancelPipelineCmd(pipeOptions *pipelineOptions) *cobra.Command {
+	options := &cancelPipelineOptions{
+		pipelineOptions: pipeOptions,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "cancel",
+		Aliases: []string{"cancel"},
+		Short:   cancelPipelinesShort,
+		Long:    cancelPipelinesLong,
+		Example: cancelPipelinesExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cancelPipeline(cmd, options, args)
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&options.reason, "reason", "r", "", "reason for cancelling pipeline")
+	cmd.PersistentFlags().StringVarP(&options.id, "id", "i", "", "id of pipeline execution to cancel")
+	return cmd
+}
+
+func cancelPipeline(cmd *cobra.Command, options *cancelPipelineOptions, args []string) error {
+	err := cancelPipelineWithID(options, options.id)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func cancelPipelineWithID(options *cancelPipelineOptions, id string) error {
+	if id == "" {
+		return errors.New("execution ID must be passed in")
+	}
+
+	pipeline, resp, err := options.GateClient.ApplicationControllerApi.CancelPipelineUsingPUT(options.GateClient.Context, id, &gate.ApplicationControllerApiCancelPipelineUsingPUTOpts{Reason: optional.NewString(options.reason)})
+
+	if resp != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Execution ID '%s' not found\n", options.id)
+		} else if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("Encountered an error getting execution ID, status code: %d\n%v", resp.StatusCode, pipeline)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	options.Ui.Info(fmt.Sprintf("Pipeline %v was cancelled.", id))
+	return nil
+}

--- a/cmd/application/cancel_pipeline.go
+++ b/cmd/application/cancel_pipeline.go
@@ -76,9 +76,12 @@ func cancelPipelineWithID(options *cancelPipelineOptions, id string) error {
 	pipeline, resp, err := options.GateClient.ApplicationControllerApi.CancelPipelineUsingPUT(options.GateClient.Context, id, &gate.ApplicationControllerApiCancelPipelineUsingPUTOpts{Reason: optional.NewString(options.reason)})
 
 	if resp != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// pass
+		case http.StatusNotFound:
 			return fmt.Errorf("Execution ID '%s' not found\n", options.id)
-		} else if resp.StatusCode != http.StatusOK {
+		default:
 			return fmt.Errorf("Encountered an error getting execution ID, status code: %d\n%v", resp.StatusCode, pipeline)
 		}
 	}

--- a/cmd/application/cancel_pipelines.go
+++ b/cmd/application/cancel_pipelines.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2020, Anosua "Chini" Mukhopadhyay
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package application
+
+import (
+	"fmt"
+	// "github.com/antihax/optional"
+	"github.com/spf13/cobra"
+	//gate "github.com/spinnaker/spin/gateapi"
+)
+
+type cancelAllPipelinesOptions struct {
+	*pipelineOptions
+	getPipelinesOptions   getPipelinesOptions
+	cancelPipelineOptions cancelPipelineOptions
+}
+
+var (
+	cancelAllPipelinesShort   = "Cancel all the pipelines for the specified application with the specified status"
+	cancelAllPipelinesLong    = "Cancel all the pipelines for the specified application with the specified status"
+	cancelAllPipelinesExample = "usage: spin application pipelines cancel-all [options] id reason"
+)
+
+func NewCancelAllPipelinesCmd(pipeOptions *pipelineOptions) *cobra.Command {
+	options := &cancelAllPipelinesOptions{
+		pipelineOptions: pipeOptions,
+		getPipelinesOptions: getPipelinesOptions{
+			pipelineOptions: pipeOptions,
+			expand:          false,
+		},
+		cancelPipelineOptions: cancelPipelineOptions{
+			pipelineOptions: pipeOptions,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:     "cancel-all",
+		Aliases: []string{"cancel-all"},
+		Short:   cancelAllPipelinesShort,
+		Long:    cancelAllPipelinesLong,
+		Example: cancelAllPipelinesExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cancelAllPipelines(cmd, options, args)
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&options.getPipelinesOptions.applicationName, "application-name", "a", "", "name of the application")
+	cmd.PersistentFlags().StringVarP(&options.getPipelinesOptions.status, "status", "s", "", "status pipeline to search for")
+	cmd.PersistentFlags().StringVarP(&options.cancelPipelineOptions.reason, "reason", "r", "", "reason for cancelling pipeline")
+	return cmd
+}
+
+func cancelAllPipelines(cmd *cobra.Command, options *cancelAllPipelinesOptions, args []string) error {
+	app, err := getPipelines(cmd, &options.getPipelinesOptions, args)
+	if err != nil {
+		return err
+	}
+
+	if options.getPipelinesOptions.status == "" {
+		options.Ui.Warn(fmt.Sprintf("No status was passed in. Cancelling all pipelines under application %s", options.getPipelinesOptions.applicationName))
+	}
+
+	for _, foundPipeline := range app {
+		foundPipeline, ok := foundPipeline.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("foundPipeline should be an interface array")
+		}
+		if foundPipeline == nil {
+			return fmt.Errorf("Output in NIL")
+		}
+		for key, value := range foundPipeline {
+			if key == "id" {
+				options.Ui.Info(fmt.Sprintf("Cancelling execution ID %s...", value))
+				err := cancelPipelineWithID(&options.cancelPipelineOptions, fmt.Sprintf("%v", value))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/application/get_pipelines.go
+++ b/cmd/application/get_pipelines.go
@@ -78,9 +78,12 @@ func getPipelines(cmd *cobra.Command, options *getPipelinesOptions, args []strin
 
 	app, resp, err := options.GateClient.ApplicationControllerApi.GetPipelinesUsingGET(options.GateClient.Context, options.applicationName, &gate.ApplicationControllerApiGetPipelinesUsingGETOpts{Expand: optional.NewBool(options.expand), Statuses: optional.NewString(options.status)})
 	if resp != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// pass
+		case http.StatusNotFound:
 			return nil, fmt.Errorf("Application '%s' not found\n", options.applicationName)
-		} else if resp.StatusCode != http.StatusOK {
+		default:
 			return nil, fmt.Errorf("Encountered an error getting application, status code: %d\n", resp.StatusCode)
 		}
 	}

--- a/cmd/application/get_pipelines.go
+++ b/cmd/application/get_pipelines.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2020, Anosua "Chini" Mukhopadhyay
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package application
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/antihax/optional"
+	"github.com/spf13/cobra"
+
+	gate "github.com/spinnaker/spin/gateapi"
+)
+
+type getPipelinesOptions struct {
+	*pipelineOptions
+	applicationName string
+	expand          bool
+	status          string
+}
+
+var (
+	getPipelinesShort   = "Get the pipelines for the specified application"
+	getPipelinesLong    = "Get the pipelines for the specified application"
+	getPipelinesExample = "usage: spin application pipelines get [options] application-name status"
+)
+
+func NewGetPipelinesCmd(pipeOptions *pipelineOptions) *cobra.Command {
+	options := &getPipelinesOptions{
+		pipelineOptions: pipeOptions,
+		expand:          false,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "get",
+		Aliases: []string{"get"},
+		Short:   getPipelinesShort,
+		Long:    getPipelinesLong,
+		Example: getPipelinesExample,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getPipelinesWithOutput(cmd, options, args)
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&options.applicationName, "application-name", "a", "", "name of the application")
+	cmd.PersistentFlags().StringVarP(&options.status, "status", "s", "", "status pipeline to search for")
+	cmd.PersistentFlags().BoolVarP(&options.expand, "expand", "x", false, "expand app payload to include clusters")
+	return cmd
+}
+
+func getPipelinesWithOutput(cmd *cobra.Command, options *getPipelinesOptions, args []string) error {
+	app, err := getPipelines(cmd, options, args)
+	if err != nil {
+		return err
+	}
+
+	options.Ui.JsonOutput(app)
+	return nil
+}
+
+func getPipelines(cmd *cobra.Command, options *getPipelinesOptions, args []string) ([]interface{}, error) {
+	if options.applicationName == "" {
+		return nil, errors.New("Application name must be passed in")
+	}
+
+	app, resp, err := options.GateClient.ApplicationControllerApi.GetPipelinesUsingGET(options.GateClient.Context, options.applicationName, &gate.ApplicationControllerApiGetPipelinesUsingGETOpts{Expand: optional.NewBool(options.expand), Statuses: optional.NewString(options.status)})
+	if resp != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("Application '%s' not found\n", options.applicationName)
+		} else if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Encountered an error getting application, status code: %d\n", resp.StatusCode)
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return app, nil
+}

--- a/cmd/application/pipelines.go
+++ b/cmd/application/pipelines.go
@@ -1,0 +1,34 @@
+package application
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type pipelineOptions struct {
+	*applicationOptions
+}
+
+var (
+	pipelinesShort   = ""
+	pipelinesLong    = ""
+	pipelinesExample = ""
+)
+
+func NewPipelineCmd(appOptions *applicationOptions) *cobra.Command {
+	options := &pipelineOptions{
+		applicationOptions: appOptions,
+	}
+	cmd := &cobra.Command{
+		Use:     "pipelines",
+		Aliases: []string{"pipelines", "pipes"},
+		Short:   pipelinesShort,
+		Long:    pipelinesLong,
+		Example: pipelinesExample,
+	}
+
+	// create subcommands
+	cmd.AddCommand(NewGetPipelinesCmd(options))
+	cmd.AddCommand(NewCancelPipelineCmd(options))
+	cmd.AddCommand(NewCancelAllPipelinesCmd(options))
+	return cmd
+}


### PR DESCRIPTION
This PR adds a pipeline subcommand to `spin application` with 3 subcommand options.

`spin application pipelines get -a <appName>` will list all executions of a pipeline under an application name.

You can narrow this down by passing the status of the pipeline you're looking for. i.e. `-s RUNNING` for example or `-s NOT_STARTED`

If you have the execution ID of a pipeline, you can do:

`spin application pipelines cancel -i <ID>`

If you want to cancel all the pipelines of a particular status under an application and pass a reason for it, you can run:

`spin application pipelines cancel-all -a <appName> -s RUNNING -r "killing zombie executions"`

If you don't pass the status, it will cancel all executions.