### PR TITLE
chore(config): Ensure consistent marshalling/unmarshalling

### DIFF
--- a/config/auth/authconfig.go
+++ b/config/auth/authconfig.go
@@ -25,13 +25,13 @@ import (
 
 // Config is the CLI's authentication configuration.
 type Config struct {
-	Enabled          bool           `yaml:"enabled"`
-	IgnoreCertErrors bool           `yaml:"ignoreCertErrors"`
-	X509             *x509.Config   `yaml:"x509,omitempty"`
-	OAuth2           *oauth2.Config `yaml:"oauth2,omitempty"`
-	Basic            *basic.Config  `yaml:"basic,omitempty"`
-	Iap              *config.Config `yaml:"iap,omitempty"`
-	Ldap             *ldap.Config   `yaml:"ldap,omitempty"`
+	Enabled          bool           `json:"enabled" yaml:"enabled"`
+	IgnoreCertErrors bool           `json:"ignoreCertErrors" yaml:"ignoreCertErrors"`
+	X509             *x509.Config   `json:"x509,omitempty" yaml:"x509,omitempty"`
+	OAuth2           *oauth2.Config `json:"oauth2,omitempty" yaml:"oauth2,omitempty"`
+	Basic            *basic.Config  `json:"basic,omitempty" yaml:"basic,omitempty"`
+	Iap              *config.Config `json:"iap,omitempty" yaml:"iap,omitempty"`
+	Ldap             *ldap.Config   `json:"ldap,omitempty" yaml:"ldap,omitempty"`
 
-	GoogleServiceAccount *gsa.Config `yaml:"google_service_account,omitempty"`
+	GoogleServiceAccount *gsa.Config `json:"google_service_account,omitempty" yaml:"google_service_account,omitempty"`
 }

--- a/config/auth/basic/config.go
+++ b/config/auth/basic/config.go
@@ -15,8 +15,8 @@
 package basic
 
 type Config struct {
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
+	Username string `json:"username" yaml:"username"`
+	Password string `json:"password" yaml:"password"`
 }
 
 func (b *Config) IsValid() bool {

--- a/config/auth/googleserviceaccount/config.go
+++ b/config/auth/googleserviceaccount/config.go
@@ -19,9 +19,9 @@ package googleserviceaccount
 import "golang.org/x/oauth2"
 
 type Config struct {
-	File string `yaml:"file"`
+	File string `json:"file" yaml:"file"`
 
-	CachedToken *oauth2.Token `yaml:"cachedToken,omitempty"`
+	CachedToken *oauth2.Token `json:"cachedToken,omitempty" yaml:"cachedToken,omitempty"`
 }
 
 func (g *Config) IsEnabled() bool {

--- a/config/auth/iap/config.go
+++ b/config/auth/iap/config.go
@@ -16,10 +16,10 @@ package config
 
 // Config mapping to the config file for IAP
 type Config struct {
-	OAuthClientId         string `yaml:"oauthClientId"`
-	OAuthClientSecret     string `yaml:"oauthClientSecret"`
-	IapClientId           string `yaml:"iapClientId"`
-	IapClientRefresh      string `yaml:"iapClientRefresh"`
-	IapIdToken            string `yaml:"iapIdToken"`
-	ServiceAccountKeyPath string `yaml:"serviceAccountKeyPath"`
+	OAuthClientId         string `json:"oauthClientId" yaml:"oauthClientId"`
+	OAuthClientSecret     string `json:"oauthClientSecret" yaml:"oauthClientSecret"`
+	IapClientId           string `json:"iapClientId" yaml:"iapClientId"`
+	IapClientRefresh      string `json:"iapClientRefresh" yaml:"iapClientRefresh"`
+	IapIdToken            string `json:"iapIdToken" yaml:"iapIdToken"`
+	ServiceAccountKeyPath string `json:"serviceAccountKeyPath" yaml:"serviceAccountKeyPath"`
 }

--- a/config/auth/ldap/config.go
+++ b/config/auth/ldap/config.go
@@ -1,8 +1,8 @@
 package ldap
 
 type Config struct {
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
+	Username string `json:"username" yaml:"username"`
+	Password string `json:"password" yaml:"password"`
 }
 
 func (l *Config) IsValid() bool {

--- a/config/auth/oauth2/config.go
+++ b/config/auth/oauth2/config.go
@@ -21,12 +21,12 @@ import (
 // Config is the configuration for using OAuth2.0 to
 // authenticate with Spinnaker
 type Config struct {
-	TokenUrl     string        `yaml:"tokenUrl"`
-	AuthUrl      string        `yaml:"authUrl"`
-	ClientId     string        `yaml:"clientId"`
-	ClientSecret string        `yaml:"clientSecret"`
-	Scopes       []string      `yaml:"scopes"`
-	CachedToken  *oauth2.Token `yaml:"cachedToken,omitempty"`
+	TokenUrl     string        `json:"tokenUrl" yaml:"tokenUrl"`
+	AuthUrl      string        `json:"authUrl" yaml:"authUrl"`
+	ClientId     string        `json:"clientId" yaml:"clientId"`
+	ClientSecret string        `json:"clientSecret" yaml:"clientSecret"`
+	Scopes       []string      `json:"scopes" yaml:"scopes"`
+	CachedToken  *oauth2.Token `json:"cachedToken,omitempty" yaml:"cachedToken,omitempty"`
 }
 
 func (x *Config) IsValid() bool {

--- a/config/auth/x509/config.go
+++ b/config/auth/x509/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	CertPath string `json:"certPath" yaml:"certPath"`
 	KeyPath  string `json:"keyPath" yaml:"keyPath"`
 	Cert     string `json:"cert" yaml:"cert"` // Cert is base64 encoded PEM block.
-	Key      string `json:"key" yaml:"key"`  // Key is base64 encoded PEM block.
+	Key      string `json:"key" yaml:"key"`   // Key is base64 encoded PEM block.
 }
 
 func (x *Config) IsValid() bool {

--- a/config/auth/x509/config.go
+++ b/config/auth/x509/config.go
@@ -17,10 +17,10 @@ package x509
 // Config is the configuration for using X.509 certs to
 // authenticate with Spinnaker.
 type Config struct {
-	CertPath string `yaml:"certPath"`
-	KeyPath  string `yaml:"keyPath"`
-	Cert     string `yaml:"cert"` // Cert is base64 encoded PEM block.
-	Key      string `yaml:"key"`  // Key is base64 encoded PEM block.
+	CertPath string `json:"certPath" yaml:"certPath"`
+	KeyPath  string `json:"keyPath" yaml:"keyPath"`
+	Cert     string `json:"cert" yaml:"cert"` // Cert is base64 encoded PEM block.
+	Key      string `json:"key" yaml:"key"`  // Key is base64 encoded PEM block.
 }
 
 func (x *Config) IsValid() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ import (
 // Config is the CLI configuration kept in '~/.spin/config'.
 type Config struct {
 	Gate struct {
-		Endpoint string `yaml:"endpoint"`
-	} `yaml:"gate"`
-	Auth *auth.Config `yaml:"auth"`
+		Endpoint string `json:"endpoint" yaml:"endpoint"`
+	} `json:"gate" yaml:"gate"`
+	Auth *auth.Config `json:"auth" yaml:"auth"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestBasicMarshalling(t *testing.T) {
+	var cfg Config
+
+	cfg.Gate.Endpoint = "test"
+
+	bs, err := yaml.Marshal(cfg)
+
+	if err != nil {
+		t.Errorf("Unexpected error unmarshalling YAML: %v", err)
+	}
+
+	got := string(bs)
+	want := "auth: null\ngate:\n  endpoint: test\n"
+
+	if got != want {
+		t.Errorf("Unexpected marshalled YAML, saw '%s', want '%s'", got, want)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,16 +11,37 @@ func TestBasicMarshalling(t *testing.T) {
 
 	cfg.Gate.Endpoint = "test"
 
-	bs, err := yaml.Marshal(cfg)
+	byteSlice, err := yaml.Marshal(cfg)
 
 	if err != nil {
-		t.Errorf("Unexpected error unmarshalling YAML: %v", err)
+		t.Errorf("Unexpected error marshalling YAML: %v", err)
 	}
 
-	got := string(bs)
+	got := string(byteSlice)
 	want := "auth: null\ngate:\n  endpoint: test\n"
 
 	if got != want {
 		t.Errorf("Unexpected marshalled YAML, saw '%s', want '%s'", got, want)
+	}
+}
+
+func TestYAMLRoundTrip(t *testing.T) {
+	var cfg Config
+
+	want := "auth:\n  enabled: false\n  ignoreCertErrors: true\ngate:\n  endpoint: test\n"
+	err := yaml.Unmarshal([]byte(want), &cfg)
+
+	if err != nil {
+		t.Errorf("Unexpected unmarshalling error: %v", err)
+	}
+
+	byteSlice, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Errorf("Unexpected marshalling error: %v", err)
+	}
+
+	got := string(byteSlice)
+	if got != want {
+		t.Errorf("Round-tripped YAML does not match: saw '%s', want '%s'", got, want)
 	}
 }


### PR DESCRIPTION
The sigs.k8s.io/yaml package round-trips YAML through JSON. This means that
without JSON tags on structs, they end up getting the default JSON naming
once marshalled. This change adds JSON tags to all structs, making sure that
the tags after writing the config file back is consistent with what the tags in the source code say.

This PR provides a fix for https://github.com/spinnaker/spinnaker/issues/6434