### PR TITLE
feat(spin): Container improvements, non-root, exec spin, :latest tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,5 +88,6 @@ jobs:
           build-args: |
             "VERSION=${{ steps.build_variables.outputs.VERSION }}"
           tags: |
+            "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:latest"
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ github.ref_name }}-latest"
             "${{ env.CONTAINER_REGISTRY }}/${{ steps.build_variables.outputs.REPO }}:${{ steps.build_variables.outputs.VERSION }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.15 as build
-ARG VERSION
+ARG VERSION=dev
 
 WORKDIR /app
 COPY ./ ./
@@ -17,4 +17,8 @@ RUN apk update \
 
 COPY --from=build /app/spin /usr/local/bin
 
-CMD ["/bin/sh"]
+RUN addgroup -S -g 10111 spinnaker
+RUN adduser -S -G spinnaker -u 10111 spinnaker
+USER spinnaker
+
+ENTRYPOINT ["spin"]


### PR DESCRIPTION
Following the principle of least privilege we should not run as root
user. There is no need.
Match other Spinnaker services and run as a high user id.

Additional containers generally run the application process as
the entrypoint rather than a shell.
This makes performing commands simpler as we can tack on any arguments
to the end of the image like so:

```
$ docker run --rm -it spin:latest --version
version dev
```

The `VERSION` build arg now defaults to `dev` otherwise an empty VERSION
string overwrites default in Go and results in the `--version` flag
disappearing.