### PR TITLE
chore(ci): Mergify - merge Autobumps on release-*

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,59 +8,56 @@ pull_request_rules:
     conditions:
       - base=master
       - status-success=build
-      - 'label=ready to merge'
-      - 'approved-reviews-by=@oss-approvers'
+      - "label=ready to merge"
+      - "approved-reviews-by=@oss-approvers"
     actions:
       queue:
         method: squash
         name: default
       label:
-        add: ['auto merged']
+        add: ["auto merged"]
   - name: Automatically merge release branch changes on CI success and release manager review
-    conditions:
-      - base=master
-      - status-success=build
-      - 'label=ready to merge'
-      - 'label=self merge'
-    actions:
-      queue:
-        method: squash
-        name: default
-      label:
-        add: ['auto merged']
-  - name: Automatically rebase and merge on CI success and review
-    conditions:
-      - base=master
-      - status-success=build
-      - 'label=ready to rebase'
-      - 'approved-reviews-by=@oss-approvers'
-    actions:
-      queue:
-        method: rebase
-        name: default
-      label:
-        add: ['auto merged']
-  - name: Automatically rebase and self merge on CI success
-    conditions:
-      - base=master
-      - status-success=build
-      - 'label=ready to rebase'
-      - 'label=self merge'
-    actions:
-      queue:
-        method: rebase
-        name: default
-      label:
-        add: ['auto merged']
-  - name: Automatically merge release branch changes on Travis CI success and release manager review
     conditions:
       - base~=^release-
       - status-success=build
-      - 'label=ready to merge'
-      - 'approved-reviews-by=@release-managers'
+      - "label=ready to merge"
+      - "approved-reviews-by=@release-managers"
     actions:
       queue:
         method: squash
         name: default
       label:
-        add: ['auto merged']
+        add: ["auto merged"]
+  - name: Automatically merge PRs from maintainers on CI success and review
+    conditions:
+      - base=master
+      - status-success=build
+      - "label=ready to merge"
+      - "author=@oss-approvers"
+    actions:
+      queue:
+        method: squash
+        name: default
+      label:
+        add: ["auto merged"]
+  - name: Automatically merge autobump PRs on CI success
+    conditions:
+      - base~=^(master|release-)
+      - status-success=build
+      - "label~=autobump-*"
+      - "author:spinnakerbot"
+    actions:
+      queue:
+        method: squash
+        name: default
+      label:
+        add: ["auto merged"]
+  - name: Request reviews for autobump PRs on CI failure
+    conditions:
+      - base~=^(master|release-)
+      - status-failure=build
+      - "label~=autobump-*"
+      - base=master
+    actions:
+      request_reviews:
+        teams: ["oss-approvers"]


### PR DESCRIPTION
And request review for failed autobump builds on master and release branches.

We don't do any autobumps for `spin` but this is a copy paste of the `.mergify.yml` file from other repo's and keeps it in sync until we get a single GHA to rule them all.