### PR TITLE
feat(spin): Allow rewriting id of pipeline that is already exists

### DIFF
--- a/cmd/pipeline/save.go
+++ b/cmd/pipeline/save.go
@@ -27,8 +27,9 @@ import (
 
 type saveOptions struct {
 	*PipelineOptions
-	output       string
-	pipelineFile string
+	output              string
+	pipelineFile        string
+	overwritePipelineId bool
 }
 
 var (
@@ -51,6 +52,7 @@ func NewSaveCmd(pipelineOptions *PipelineOptions) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&options.pipelineFile, "file", "f", "", "path to the pipeline file")
+	cmd.PersistentFlags().BoolVarP(&options.overwritePipelineId, "overwrite-pipeline-id", "o", false, "Danger. Forcely set existing pipeline id")
 
 	return cmd
 }
@@ -89,8 +91,8 @@ func savePipeline(cmd *cobra.Command, options *saveOptions) error {
 	foundPipeline, queryResp, _ := options.GateClient.ApplicationControllerApi.GetPipelineConfigUsingGET(options.GateClient.Context, application, pipelineName)
 	switch queryResp.StatusCode {
 	case http.StatusOK:
-		// pipeline found, let's use Spinnaker's known Pipeline ID, otherwise we'll get one created for us
-		if len(foundPipeline) > 0 {
+		// pipeline found, let's use Spinnaker's known Pipeline ID and we didn't set flag to overwrite it, otherwise we'll get one created for us
+		if len(foundPipeline) > 0 && !options.overwritePipelineId {
 			pipelineJson["id"] = foundPipeline["id"].(string)
 		}
 	case http.StatusNotFound:

--- a/cmd/pipeline/save.go
+++ b/cmd/pipeline/save.go
@@ -33,8 +33,9 @@ type saveOptions struct {
 }
 
 var (
-	savePipelineShort = "Save the provided pipeline"
-	savePipelineLong  = "Save the provided pipeline"
+	savePipelineShort   = "Save the provided pipeline"
+	savePipelineLong    = "Save the provided pipeline"
+	overwritePipelineId bool
 )
 
 func NewSaveCmd(pipelineOptions *PipelineOptions) *cobra.Command {
@@ -52,7 +53,7 @@ func NewSaveCmd(pipelineOptions *PipelineOptions) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVarP(&options.pipelineFile, "file", "f", "", "path to the pipeline file")
-	cmd.PersistentFlags().BoolVarP(&options.overwritePipelineId, "overwrite-pipeline-id", "o", false, "Danger. Forcely set existing pipeline id")
+	cmd.PersistentFlags().BoolVar(&overwritePipelineId, "overwrite-pipeline-id", false, "Danger. Forcely set existing pipeline id")
 
 	return cmd
 }


### PR DESCRIPTION
Problem:
After generating and saving existing pipeline it seems that spinnaker rewrites pipeline id, so pipelines that trigger other pipelines by `id` will fail.

Proposal:
Add flag to overwrite pipeline id on spinnaker.