### PR TITLE
fix(output): send info strings to stderr

### DIFF
--- a/cmd/output/cli_ui.go
+++ b/cmd/output/cli_ui.go
@@ -81,19 +81,20 @@ func (u *ColorizeUi) JsonOutput(data interface{}) {
 	output, err := u.OutputFormater(data)
 	if err != nil {
 		u.Error(fmt.Sprintf("%v", err))
+		return
 	}
 	u.Output(string(output))
 }
 
 func (u *ColorizeUi) Success(message string) {
 	if !u.Quiet {
-		u.Ui.Info(u.colorize(message, u.SuccessColor))
+		u.Ui.Warn(u.colorize(message, u.SuccessColor))
 	}
 }
 
 func (u *ColorizeUi) Info(message string) {
 	if !u.Quiet {
-		u.Ui.Info(u.colorize(message, u.InfoColor))
+		u.Ui.Warn(u.colorize(message, u.InfoColor))
 	}
 }
 


### PR DESCRIPTION
Currently the tool sends out informational output to stdout. This makes it hard to pipe output into tools like `jq` and such. 

Adjusts it so only jsonoutput and output go to stdout and the rest should go to stderr via warn. 