### PR TITLE
Allow polling timeout to be configurable

### DIFF
--- a/cmd/application/delete.go
+++ b/cmd/application/delete.go
@@ -90,7 +90,7 @@ func deleteApplication(cmd *cobra.Command, options *deleteOptions, args []string
 		return fmt.Errorf("Encountered an error deleting application, status code: %d\n", resp.StatusCode)
 	}
 
-	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, taskRef, 5)
+	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, taskRef)
 	if err != nil {
 		return err
 	}

--- a/cmd/application/save.go
+++ b/cmd/application/save.go
@@ -108,7 +108,7 @@ func saveApplication(cmd *cobra.Command, options *saveOptions) error {
 		return err
 	}
 
-	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref, 5)
+	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref)
 	if err != nil {
 		return err
 	}

--- a/cmd/gateclient/client.go
+++ b/cmd/gateclient/client.go
@@ -85,6 +85,9 @@ type GatewayClient struct {
 	httpClient *http.Client
 
 	ui output.Ui
+
+	// Maximum time to wait (when polling) for a task to become completed.
+	retryTimeout int
 }
 
 func (m *GatewayClient) GateEndpoint() string {
@@ -97,13 +100,24 @@ func (m *GatewayClient) GateEndpoint() string {
 	return m.Config.Gate.Endpoint
 }
 
+func (m *GatewayClient) RetryTimeout() int {
+	if m.Config.Gate.RetryTimeout == 0 && m.retryTimeout == 0 {
+		return 60
+	}
+	if m.retryTimeout != 0 {
+		return m.retryTimeout
+	}
+	return m.Config.Gate.RetryTimeout
+}
+
 // Create new spinnaker gateway client with flag
-func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation string, ignoreCertErrors bool, ignoreRedirects bool) (*GatewayClient, error) {
+func NewGateClient(ui output.Ui, gateEndpoint, defaultHeaders, configLocation string, ignoreCertErrors bool, ignoreRedirects bool, retryTimeout int) (*GatewayClient, error) {
 	gateClient := &GatewayClient{
 		gateEndpoint:     gateEndpoint,
 		ignoreCertErrors: ignoreCertErrors,
 		ignoreRedirects:  ignoreRedirects,
 		ui:               ui,
+		retryTimeout:     retryTimeout,
 		Context:          context.Background(),
 	}
 

--- a/cmd/orca-tasks/task_watcher_test.go
+++ b/cmd/orca-tasks/task_watcher_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 OpsMx, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package orca_tasks
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_calculateSleepTime(t *testing.T) {
+	type args struct {
+		now         int64
+		lastTryTime int64
+		attempts    int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Duration
+	}{
+		{
+			"attempt 1, lots of time remaining",
+			args{100, 100000, 1},
+			time.Duration(1) * time.Second,
+		},
+		{
+			"attempt 2, lots of time remaining",
+			args{100, 100000, 2},
+			time.Duration(4) * time.Second,
+		},
+		{
+			"attempt 100, lots of time remaining",
+			args{100, 100000, 100},
+			time.Duration(20) * time.Second,
+		},
+		{
+			"attempt 10, 5 seconds remaining",
+			args{0, 5, 10},
+			time.Duration(6) * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calculateSleepTime(tt.args.now, tt.args.lastTryTime, tt.args.attempts); got != tt.want {
+				t.Errorf("calculateSleepTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/project/delete.go
+++ b/cmd/project/delete.go
@@ -74,7 +74,7 @@ func deleteProject(cmd *cobra.Command, options *saveOptions) error {
 		return err
 	}
 
-	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref, 5)
+	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref)
 	if err != nil {
 		return err
 	}

--- a/cmd/project/save.go
+++ b/cmd/project/save.go
@@ -103,7 +103,7 @@ func saveProject(cmd *cobra.Command, options *saveOptions) error {
 		return err
 	}
 
-	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref, 5)
+	err = orca_tasks.WaitForSuccessfulTask(options.GateClient, ref)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ func NewCmdRoot(outWriter, errWriter io.Writer) (*cobra.Command, *RootOptions) {
 	cmd.PersistentFlags().BoolVarP(&options.ignoreCertErrors, "insecure", "k", false, "ignore certificate errors")
 	cmd.PersistentFlags().BoolVarP(&options.ignoreRedirects, "ignore-redirects", "", false, "ignore redirects")
 	cmd.PersistentFlags().StringVar(&options.defaultHeaders, "default-headers", "", "configure default headers for gate client as comma separated list (e.g. key1=value1,key2=value2)")
-	cmd.PersistentFlags().IntVar(&options.retryTimeout, "retry-timeout", 60, "maximum time to wait for tasks to complete in seconds (default 60)")
+	cmd.PersistentFlags().IntVar(&options.retryTimeout, "retry-timeout", 0, "maximum time to wait for tasks to complete in seconds (default 60)")
 
 	// UI Flags
 	cmd.PersistentFlags().BoolVarP(&options.quiet, "quiet", "q", false, "squelch non-essential output")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ type RootOptions struct {
 	color            bool
 	outputFormat     string
 	defaultHeaders   string
+	retryTimeout     int
 
 	Ui         output.Ui
 	GateClient *gateclient.GatewayClient
@@ -43,6 +44,7 @@ func NewCmdRoot(outWriter, errWriter io.Writer) (*cobra.Command, *RootOptions) {
 	cmd.PersistentFlags().BoolVarP(&options.ignoreCertErrors, "insecure", "k", false, "ignore certificate errors")
 	cmd.PersistentFlags().BoolVarP(&options.ignoreRedirects, "ignore-redirects", "", false, "ignore redirects")
 	cmd.PersistentFlags().StringVar(&options.defaultHeaders, "default-headers", "", "configure default headers for gate client as comma separated list (e.g. key1=value1,key2=value2)")
+	cmd.PersistentFlags().IntVar(&options.retryTimeout, "retry-timeout", 60, "maximum time to wait for tasks to complete in seconds (default 60)")
 
 	// UI Flags
 	cmd.PersistentFlags().BoolVarP(&options.quiet, "quiet", "q", false, "squelch non-essential output")
@@ -66,6 +68,7 @@ func NewCmdRoot(outWriter, errWriter io.Writer) (*cobra.Command, *RootOptions) {
 			options.configPath,
 			options.ignoreCertErrors,
 			options.ignoreRedirects,
+			options.retryTimeout,
 		)
 		if err != nil {
 			return err

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,8 @@ import (
 // Config is the CLI configuration kept in '~/.spin/config'.
 type Config struct {
 	Gate struct {
-		Endpoint string `json:"endpoint" yaml:"endpoint"`
+		Endpoint     string `json:"endpoint" yaml:"endpoint"`
+		RetryTimeout int    `json:"retryTimeout,omitempty" yaml:"retryTimeout,omitempty"`
 	} `json:"gate" yaml:"gate"`
 	Auth *auth.Config `json:"auth" yaml:"auth"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,7 +28,7 @@ func TestBasicMarshalling(t *testing.T) {
 func TestYAMLRoundTrip(t *testing.T) {
 	var cfg Config
 
-	want := "auth:\n  enabled: false\n  ignoreCertErrors: true\n  ignoreRedirects: true\ngate:\n  endpoint: test\n"
+	want := "auth:\n  enabled: false\n  ignoreCertErrors: true\n  ignoreRedirects: true\ngate:\n  endpoint: test\n  retryTimeout: 900\n"
 	err := yaml.Unmarshal([]byte(want), &cfg)
 
 	if err != nil {

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -2,6 +2,7 @@
 
 gate:
   endpoint: https://my-spinnaker-gate:8084
+  retryTimeout: 300
 auth:
   enabled: true
   x509:


### PR DESCRIPTION
The old system tried 5 times with an exponential backoff.  The new behavior is based on time, and increases to a maximum of 20 seconds between tries.  It will poll for whatever time is specified on the command line, or in the config file.  Default is 60 seconds, which is the same time the old method would end up using.