### PR TITLE
fix empty list template response

### DIFF
--- a/cmd/pipeline-template/list.go
+++ b/cmd/pipeline-template/list.go
@@ -56,7 +56,7 @@ func NewListCmd(pipelineTemplateOptions *pipelineTemplateOptions) *cobra.Command
 
 func listPipelineTemplate(cmd *cobra.Command, options *listOptions) error {
 	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.ListUsingGET1(options.GateClient.Context,
-		&gate.V2PipelineTemplatesControllerApiListUsingGET1Opts{Scopes: optional.NewInterface(options.scopes)})
+		&gate.V2PipelineTemplatesControllerApiListUsingGET1Opts{Scopes: optional.NewInterface(*options.scopes)})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When running `spin pipeline-template list` I was receiving an empty list
This is because the path of the request looked like that
```
/gate/v2/pipelineTemplates?scopes=%26%5B%5D
```

the charactere `%26%5B%5D` decodes to `&[]`
Technically we could say the issue comes from `parameterToString` in client.go, and that function should handle receiving a pointer to an array better.

But since this part is generated, here is a fix on the command layer.
To send an array instead of a pointer to an array

