### PR TITLE
fix(pipelineTemplateList): Only pass scopes if explicitly provided

### DIFF
--- a/cmd/pipeline-template/list.go
+++ b/cmd/pipeline-template/list.go
@@ -55,8 +55,16 @@ func NewListCmd(pipelineTemplateOptions *pipelineTemplateOptions) *cobra.Command
 }
 
 func listPipelineTemplate(cmd *cobra.Command, options *listOptions) error {
-	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.ListUsingGET1(options.GateClient.Context,
-		&gate.V2PipelineTemplatesControllerApiListUsingGET1Opts{Scopes: optional.NewInterface(*options.scopes)})
+	var opts *gate.V2PipelineTemplatesControllerApiListUsingGET1Opts
+
+	// Only pass scopes if they were explicitly provided (non-empty)
+	if len(*options.scopes) > 0 {
+		opts = &gate.V2PipelineTemplatesControllerApiListUsingGET1Opts{Scopes: optional.NewInterface(*options.scopes)}
+	} else {
+		opts = nil
+	}
+
+	successPayload, resp, err := options.GateClient.V2PipelineTemplatesControllerApi.ListUsingGET1(options.GateClient.Context, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Issue Summary
The `list` API for pipeline templates in Spin CLI is appending a scopes query param even when it's not explicitly provided. This results in an unnecessary filter being added, as seen in the logs from Gate pods:
```
?scopes=%26%5B%5D
```
This corresponds to an empty slice (`&[]`) in Golang, and causes unintended behaviour.

This PR ensures that scopes is only included in the API call when it's explicitly specified.

Here are the logs from spin-gate pod before and after the fix 👇 
| Before | After  |
|--------|--------|
|```2025-06-18 14:02:23.180  INFO 1 --- [0.0-8084-exec-7] okhttp3.OkHttpClient  : --> GET http://spin-front50.spinnaker:8080/v2/pipelineTemplates?scopes=%26%5B%5D``` |```2025-06-18 14:02:28.746  INFO 1 --- [.0-8084-exec-10] okhttp3.OkHttpClient  : --> GET http://spin-front50.spinnaker:8080/v2/pipelineTemplates``` |
|```2025-06-18 14:02:23.193  INFO 1 --- [0.0-8084-exec-7] brave.Tracer : {"traceId":"dfd4eba0929c9364","id":"dfd4eba0929c9364","kind":"CLIENT","name":"GET","timestamp":1750255343181234,"duration":12310,"localEndpoint":{"serviceName":"unknown","ipv4":"10.244.0.17"},"tags":{"http.method":"GET","http.path":"/v2/pipelineTemplates"}}``` |```2025-06-18 14:02:28.750  INFO 1 --- [.0-8084-exec-10] brave.Tracer : {"traceId":"331dec1e1c72409a","id":"331dec1e1c72409a","kind":"CLIENT","name":"GET","timestamp":1750255348746452,"duration":3613,"localEndpoint":{"serviceName":"unknown","ipv4":"10.244.0.17"},"tags":{"http.method":"GET","http.path":"/v2/pipelineTemplates"}}``` |
|```2025-06-18 14:02:23.193  INFO 1 --- [0.0-8084-exec-7] okhttp3.OkHttpClient : <-- 200 http://spin-front50.spinnaker:8080/v2/pipelineTemplates?scopes=%26%5B%5D (12ms, unknown-length body)``` | ```2025-06-18 14:02:28.750  INFO 1 --- [.0-8084-exec-10] okhttp3.OkHttpClient : <-- 200 http://spin-front50.spinnaker:8080/v2/pipelineTemplates (3ms, unknown-length body)```|

### Environment
* Spin CLI Version: `1.30.0` (Surprisingly this issue is not available in `2025.0.4` version of Spin CLI which could be installed from https://storage.googleapis.com/spinnaker-artifacts/spin/ as documented in [Install and Configure Spin CLI page](https://spinnaker.io/docs/setup/other_config/spin/)
* Spinnaker Version: `2025.0.4`

### Commands
| Command | Actual Output | Expected Output |
|--------|--------|----|
|`spin pipeline-template list`|`[]`|`# printing the list of pipeline-templates in a json array`|

Tests included. 
